### PR TITLE
frozendict support on alpine-ros

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1394,6 +1394,11 @@ python-freezegun-pip:
   ubuntu:
     pip:
       packages: [freezegun]
+python-frozendict:
+  alpine: [py2-frozendict]
+  debian: [python-frozendict]
+  fedora: [python-frozendict]
+  ubuntu: [python-frozendict]
 python-ftdi1:
   debian: [python-ftdi1]
   fedora: [python2-libftdi]


### PR DESCRIPTION
Debian: https://packages.debian.org/sid/python-frozendict
Ubuntu: https://packages.ubuntu.com/source/xenial/python-frozendict
Fedora: https://apps.fedoraproject.org/packages/python-frozendict