### PR TITLE
Support parameterized for alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2492,6 +2492,7 @@ python-pandas:
   gentoo: [dev-python/pandas]
   ubuntu: [python-pandas]
 python-parameterized:
+  alpine: [py2-parameterized]
   debian:
     '*': [python-parameterized]
     jessie:


### PR DESCRIPTION
This supports Python `parameterized `https://pypi.org/project/parameterized/ for Alpine.