### PR TITLE
Follow upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - easy_install -U pip
   - pip install PyYAML argparse
-  - pip install catkin_pkg ros_buildfarm rosdistro nose coverage
+  - pip install catkin-pkg ros-buildfarm rosdistro nose coverage
   - pip install yamllint
   - pip install unidiff
   - pip install rosdep

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,6 @@ Guidelines for rosdep rules
    Similarly don't call out indirect dependencies or default options for packages.
  * Python packages should go in the `python.yaml`.
  * Homebrew into `osx-homebrew.yaml`.
- * If a package is only available via pip use the `-pip` extension.
  * Supported Platforms
    * Rules can be contributed for any platform.
      However to be released they must be at least cover the supported platforms in REP 3: http://www.ros.org/reps/rep-0003.html So:
@@ -111,19 +110,18 @@ Work has been proposed to add a separate installer for AUR packages [ros-infrast
 
 * Alpine Linux requires the [`edge`](https://wiki.alpinelinux.org/wiki/Edge#Upgrading_to_Edge) release and [`testing`](https://wiki.alpinelinux.org/wiki/Aports_tree#testing) aports branch.
 
-### FreeBSD
+#### FreeBSD
 
 * FreeBSD project pkg repository: main or quarterly
 * A database of FreeBSD packages is available at https://freshports.org
 
 #### pip
 
-For pip installers they are expected to be in the main pypi index.
+For pip installers they are expected to be in the main PyPI index https://pypi.org/.
 
-#### 
+### Python rules
 
-
-### Python 3 rules
+#### Python 3
 
 When adding rules for python 3 packages, create a separate entry prefixed with `python3-` rather than `python`
 For example:
@@ -141,7 +139,26 @@ python3-foobar:
 ```
 
 You may see existing rules that use `_python3`-suffixed distribution codenames.
-These were trialed as a possible style of Python 3 rules and should not be used for newly added definitions.
+These were trialed as a possible style of Python 3 rules and should not be used.
+The guidance above should be followed for new rules.
+Additionally, if you rely on a dependency that uses `_python3`-suffixed codenames, add a new rule for it that follows the guidance above.
+
+#### pip
+
+Python packages, which are only available on pip, should use the `-pip` extension. Also the `python-`/`python3-` prefix needs to be used.
+For example:
+
+```yaml
+python-foobar-pip:
+  ubuntu:
+    pip:
+      packages: [foobar]
+...
+python3-foobar-pip:
+  ubuntu:
+    pip:
+      packages: [foobar]
+```
 
 How to submit pull requests
 ---------------------------
@@ -154,11 +171,11 @@ These tests require several dependencies that can be installed either from the R
 
 |   Dependency   |            Ubuntu package         |   Pip package  |
 | :------------: | --------------------------------- | -------------- |
-| catkin_pkg     | python-catkin-pkg                 | catkin_pkg     |
+| catkin_pkg     | python-catkin-pkg                 | catkin-pkg     |
 | github         | python-github                     | PyGithub       |
 | nose           | python-nose                       | nose           |
 | rosdistro      | python-rosdistro                  | rosdistro      |
-| ros_buildfarm  | python-ros-buildfarm              | ros_buildfarm  |
+| ros_buildfarm  | python-ros-buildfarm              | ros-buildfarm  |
 | unidiff        | python-unidiff (Zesty and higher) | unidiff        |
 | yamllint       | yamllint                          | yamllint       |
 

--- a/dashing/distribution.yaml
+++ b/dashing/distribution.yaml
@@ -6,48 +6,6 @@ release_platforms:
   ubuntu:
   - bionic
 repositories:
-  Autoware.Auto:
-    doc:
-      type: git
-      url: https://gitlab.com/AutowareAuto/AutowareAuto.git
-      version: 0.0.1
-    release:
-      packages:
-      - autoware_auto_algorithm
-      - autoware_auto_cmake
-      - autoware_auto_create_pkg
-      - autoware_auto_examples
-      - autoware_auto_geometry
-      - autoware_auto_helper_functions
-      - autoware_auto_msgs
-      - euclidean_cluster
-      - euclidean_cluster_nodes
-      - hungarian_assigner
-      - kalman_filter
-      - lidar_utils
-      - localization_common
-      - localization_nodes
-      - motion_model
-      - ndt
-      - optimization
-      - point_cloud_fusion
-      - ray_ground_classifier
-      - ray_ground_classifier_nodes
-      - velodyne_driver
-      - velodyne_node
-      - voxel_grid
-      - voxel_grid_nodes
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://gitlab.com/AutowareAuto/AutowareAuto-release.git
-      version: 0.0.2-1
-    source:
-      test_commits: false
-      test_pull_requests: false
-      type: git
-      url: https://gitlab.com/AutowareAuto/AutowareAuto.git
-      version: 0.0.1
-    status: developed
   ackermann_msgs:
     doc:
       type: git
@@ -213,7 +171,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/esol-community/ament_virtualenv-release.git
-      version: 0.0.4-1
+      version: 0.0.5-5
     source:
       type: git
       url: https://github.com/esol-community/ament_virtualenv.git
@@ -235,6 +193,39 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_containers-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    status: developed
+  apex_test_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: master
+    release:
+      packages:
+      - apex_test_tools
+      - test_apex_test_tools
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_test_tools-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: master
+    status: developed
   apriltag:
     release:
       tags:
@@ -272,9 +263,10 @@ repositories:
     doc:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
-      version: dashing-devel
+      version: master
     release:
       packages:
+      - astuff_sensor_msgs
       - delphi_esr_msgs
       - delphi_mrr_msgs
       - delphi_srr_msgs
@@ -288,11 +280,11 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 3.0.0-2
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
-      version: dashing-devel
+      version: master
     status: developed
   async_web_server_cpp:
     release:
@@ -318,6 +310,21 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: developed
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      version: 0.0.2-2
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
   aws_common:
@@ -404,6 +411,21 @@ repositories:
       type: git
       url: https://github.com/ros2/cartographer_ros.git
       version: dashing
+    status: maintained
+  casadi_vendor:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor.git
+      version: master
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor-release.git
+      version: 3.5.1-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/casadi_vendor.git
+      version: master
     status: maintained
   class_loader:
     doc:
@@ -526,6 +548,25 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: crystal-devel
     status: maintained
+  costmap_converter:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: ros2
+    release:
+      packages:
+      - costmap_converter
+      - costmap_converter_msgs
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/costmap_converter-ros2-release.git
+      version: 0.1.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: ros2
+    status: developed
   cross_compile:
     release:
       tags:
@@ -852,7 +893,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.5-1
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
@@ -863,7 +904,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/boschresearch/fmilibrary_vendor-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
   foonathan_memory_vendor:
     release:
       tags:
@@ -970,7 +1011,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
@@ -1085,6 +1126,25 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/image_transport_plugins.git
+      version: ros2
+    status: maintained
+  joint_state_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
+      version: ros2
+    release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/joint_state_publisher-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/joint_state_publisher.git
       version: ros2
     status: maintained
   joystick_drivers:
@@ -1305,7 +1365,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/marti_common-release.git
-      version: 3.0.3-1
+      version: 3.0.5-2
     source:
       test_pull_requests: true
       type: git
@@ -1472,7 +1532,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/swri-robotics-gbp/novatel_gps_driver-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       test_pull_requests: true
       type: git
@@ -1570,6 +1630,21 @@ repositories:
       type: git
       url: https://github.com/osrf/osrf_testing_tools_cpp.git
       version: dashing
+    status: developed
+  pacmod3:
+    doc:
+      type: git
+      url: https://github.com/astuff/pacmod3.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/astuff/pacmod3-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod3.git
+      version: dashing-devel
     status: developed
   pcl_msgs:
     doc:
@@ -2116,6 +2191,22 @@ repositories:
       url: https://github.com/ros2/rmw_opensplice.git
       version: dashing
     status: developed
+  robot_localization:
+    doc:
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/cra-ros-pkg/robot_localization-release.git
+      version: 3.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/cra-ros-pkg/robot_localization.git
+      version: dashing-devel
+    status: maintained
   robot_state_publisher:
     doc:
       type: git
@@ -2146,6 +2237,47 @@ repositories:
       test_commits: false
       type: git
       url: https://github.com/ros2/ros1_bridge.git
+      version: dashing
+    status: developed
+  ros2_control:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: dashing
+    release:
+      packages:
+      - controller_interface
+      - controller_manager
+      - controller_parameter_server
+      - hardware_interface
+      - ros2_control
+      - test_robot_hardware
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_control-release.git
+      version: 0.0.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-controls/ros2_control.git
+      version: master
+    status: developed
+  ros2_controllers:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
+      version: dashing
+    release:
+      packages:
+      - ros_controllers
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/ros2_controllers-release.git
+      version: 0.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-controls/ros2_controllers.git
       version: dashing
     status: developed
   ros2_intel_realsense:
@@ -2197,7 +2329,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
-      version: 0.0.0-1
+      version: 0.0.2-1
     source:
       test_pull_requests: true
       type: git
@@ -2625,7 +2757,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
@@ -2656,7 +2788,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.0.2-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git
@@ -2799,22 +2931,6 @@ repositories:
       url: https://github.com/ros-visualization/rqt_srv.git
       version: crystal-devel
     status: maintained
-  rqt_tf_tree:
-    doc:
-      type: git
-      url: https://github.com/ros-visualization/rqt_tf_tree.git
-      version: dashing-devel
-    release:
-      tags:
-        release: release/dashing/{package}/{version}
-      url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.0-1
-    source:
-      test_pull_requests: true
-      type: git
-      url: https://github.com/ros-visualization/rqt_tf_tree.git
-      version: dashing-devel
-    status: maintained
   rqt_top:
     doc:
       type: git
@@ -2885,12 +3001,23 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/SteveMacenski/slam_toolbox-release.git
-      version: 2.0.2-1
+      version: 2.0.3-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: dashing-devel
+    status: developed
+  slide_show:
+    release:
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/slide_show-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/slide_show.git
+      version: master
     status: developed
   sophus:
     release:
@@ -2942,7 +3069,11 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.1.4-1
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/microROS/system_modes.git
+      version: master
     status: developed
   teleop_tools:
     doc:
@@ -2959,7 +3090,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 1.0.1-0
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
@@ -3091,11 +3222,12 @@ repositories:
       version: master
     release:
       packages:
+      - serial_driver
       - udp_driver
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros-drivers-gbp/transport_drivers-release.git
-      version: 0.0.3-1
+      version: 0.0.4-3
     source:
       type: git
       url: https://github.com/ros-drivers/transport_drivers.git
@@ -3113,7 +3245,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/aws-gbp/tts-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/tts-ros2.git
@@ -3239,6 +3371,24 @@ repositories:
       url: https://github.com/ros2/urdf.git
       version: dashing
     status: maintained
+  urdf_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    release:
+      packages:
+      - urdfdom_py
+      tags:
+        release: release/dashing/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_py-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    status: maintained
   urdfdom:
     doc:
       type: git
@@ -3318,7 +3468,7 @@ repositories:
       tags:
         release: release/dashing/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git

--- a/eloquent/distribution.yaml
+++ b/eloquent/distribution.yaml
@@ -142,6 +142,25 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: eloquent
     status: developed
+  ament_virtualenv:
+    doc:
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    release:
+      packages:
+      - ament_cmake_virtualenv
+      - ament_virtualenv
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/esol-community/ament_virtualenv-release.git
+      version: 0.0.5-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/esol-community/ament_virtualenv.git
+      version: master
+    status: developed
   angles:
     doc:
       type: git
@@ -158,6 +177,39 @@ repositories:
       url: https://github.com/ros/angles.git
       version: ros2
     status: maintained
+  apex_containers:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_containers-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_containers.git
+      version: master
+    status: developed
+  apex_test_tools:
+    doc:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: master
+    release:
+      packages:
+      - apex_test_tools
+      - test_apex_test_tools
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/ApexAI/apex_test_tools-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://gitlab.com/ApexAI/apex_test_tools.git
+      version: master
+    status: developed
   automotive_autonomy_msgs:
     doc:
       type: git
@@ -175,6 +227,21 @@ repositories:
     source:
       type: git
       url: https://github.com/astuff/automotive_autonomy_msgs.git
+      version: master
+    status: developed
+  autoware_auto_msgs:
+    doc:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
+      version: master
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs.git
       version: master
     status: developed
   behaviortree_cpp_v3:
@@ -220,7 +287,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/cartographer_ros-release.git
-      version: 1.0.9000-1
+      version: 1.0.9001-1
     source:
       test_pull_requests: true
       type: git
@@ -236,7 +303,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 1.4.0-1
+      version: 1.4.1-1
     source:
       test_pull_requests: true
       type: git
@@ -284,6 +351,22 @@ repositories:
       url: https://github.com/ros2/console_bridge_vendor.git
       version: eloquent
     status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/control_box_rst-release.git
+      version: 0.0.4-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: eloquent-devel
+    status: developed
   control_msgs:
     doc:
       type: git
@@ -299,6 +382,25 @@ repositories:
       url: https://github.com/ros-controls/control_msgs.git
       version: crystal-devel
     status: maintained
+  costmap_converter:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: ros2
+    release:
+      packages:
+      - costmap_converter
+      - costmap_converter_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/costmap_converter-ros2-release.git
+      version: 0.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/costmap_converter.git
+      version: ros2
+    status: developed
   cross_compile:
     release:
       tags:
@@ -446,7 +548,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_core-release.git
-      version: 1.0.4-1
+      version: 1.0.6-1
     source:
       test_pull_requests: true
       type: git
@@ -471,7 +573,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/yujinrobot-release/ecl_lite-release.git
-      version: 1.0.3-1
+      version: 1.0.5-1
     source:
       test_pull_requests: true
       type: git
@@ -596,13 +698,13 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 1.9.3-1
+      version: 1.9.3-2
     source:
       test_commits: false
       test_pull_requests: false
       type: git
       url: https://github.com/eProsima/Fast-RTPS.git
-      version: 141b778c66c4f1f7aeb5c55551c173e3237beae9
+      version: ros2-eloquent
     status: developed
   fmi_adapter_ros2:
     doc:
@@ -616,7 +718,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter_ros2-release.git
-      version: 0.1.6-1
+      version: 0.1.7-2
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter_ros2.git
@@ -627,7 +729,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/boschresearch/fmilibrary_vendor-release.git
-      version: 0.1.1-1
+      version: 0.2.0-1
   foonathan_memory_vendor:
     release:
       tags:
@@ -654,7 +756,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros_pkgs-release.git
-      version: 3.4.2-1
+      version: 3.4.3-1
     source:
       test_pull_requests: true
       type: git
@@ -692,7 +794,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.12.4-1
+      version: 0.12.5-1
     source:
       test_pull_requests: true
       type: git
@@ -713,6 +815,27 @@ repositories:
       url: https://github.com/ament/googletest.git
       version: ros2
     status: maintained
+  gps_umd:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    release:
+      packages:
+      - gps_msgs
+      - gps_tools
+      - gps_umd
+      - gpsd_client
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/gps_umd-release.git
+      version: 1.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/swri-robotics/gps_umd.git
+      version: dashing-devel
+    status: developed
   image_common:
     doc:
       type: git
@@ -808,38 +931,69 @@ repositories:
   kobuki_core:
     doc:
       type: git
-      url: https://github.com/yujinrobot/kobuki_core.git
-      version: release/0.8.x
+      url: https://github.com/kobuki-base/kobuki_core.git
+      version: release/1.0.x
     release:
       packages:
       - kobuki_core
       - kobuki_dock_drive
       - kobuki_driver
-      - kobuki_ftdi
       tags:
         release: release/eloquent/{package}/{version}
-      url: https://github.com/yujinrobot-release/kobuki_core-release.git
-      version: 0.8.1-1
+      url: https://github.com/stonier/kobuki_core-release.git
+      version: 1.0.0-1
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/yujinrobot/kobuki_core.git
+      url: https://github.com/kobuki-base/kobuki_core.git
       version: devel
     status: maintained
-  kobuki_msgs:
+  kobuki_ftdi:
     doc:
       type: git
-      url: https://github.com/yujinrobot/kobuki_msgs.git
-      version: release/0.8.x
+      url: https://github.com/kobuki-base/kobuki_ftdi.git
+      version: release/1.0.x
     release:
       tags:
         release: release/eloquent/{package}/{version}
-      url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
-      version: 0.8.0-1
+      url: https://github.com/stonier/kobuki_ftdi-release.git
+      version: 1.0.0-1
     source:
       type: git
-      url: https://github.com/yujinrobot/kobuki_msgs.git
-      version: release/0.8.x
+      url: https://github.com/kobuki-base/kobuki_ftdi.git
+      version: release/1.0.x
+    status: maintained
+  kobuki_ros:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_ros-release.git
+      version: 1.0.0-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros.git
+      version: release/1.0.x
+    status: maintained
+  kobuki_ros_interfaces:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/kobuki_ros_interfaces-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/kobuki_ros_interfaces.git
+      version: release/1.0.x
     status: maintained
   laser_geometry:
     doc:
@@ -850,7 +1004,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.1.0-1
+      version: 2.1.1-1
     source:
       test_pull_requests: true
       type: git
@@ -872,7 +1026,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 0.9.5-1
+      version: 0.9.6-1
     source:
       test_pull_requests: true
       type: git
@@ -892,13 +1046,20 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.9.4-1
+      version: 0.9.5-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/launch_ros.git
       version: eloquent
     status: developed
+  libg2o:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/libg2o-release.git
+      version: 2019.11.23-4
+    status: maintained
   libyaml_vendor:
     release:
       tags:
@@ -911,6 +1072,29 @@ repositories:
       url: https://github.com/ros2/libyaml_vendor.git
       version: eloquent
     status: maintained
+  marti_messages:
+    doc:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    release:
+      packages:
+      - marti_can_msgs
+      - marti_common_msgs
+      - marti_nav_msgs
+      - marti_perception_msgs
+      - marti_sensor_msgs
+      - marti_status_msgs
+      - marti_visualization_msgs
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/swri-robotics-gbp/marti_messages-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/swri-robotics/marti_messages.git
+      version: dashing-devel
+    status: developed
   mavlink:
     doc:
       type: git
@@ -920,7 +1104,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2019.12.30-1
+      version: 2020.3.3-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git
@@ -981,7 +1165,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SteveMacenski/navigation2-release.git
-      version: 0.3.2-1
+      version: 0.3.4-1
     source:
       test_pull_requests: true
       type: git
@@ -1007,6 +1191,21 @@ repositories:
       url: https://github.com/ros-planning/navigation_msgs.git
       version: eloquent
     status: maintained
+  nmea_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/nmea_msgs-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/nmea_msgs.git
+      version: ros2
+    status: maintained
   nonpersistent_voxel_layer:
     doc:
       type: git
@@ -1016,7 +1215,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SteveMacenski/nonpersistent_voxel_layer-release.git
-      version: 2.1.0-2
+      version: 2.1.1-2
     source:
       test_pull_requests: true
       type: git
@@ -1203,6 +1402,22 @@ repositories:
       url: https://github.com/ros2/poco_vendor.git
       version: eloquent
     status: maintained
+  pointcloud_to_laserscan:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/pointcloud_to_laserscan-release.git
+      version: 2.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros-perception/pointcloud_to_laserscan.git
+      version: eloquent-devel
+    status: maintained
   popf:
     doc:
       type: git
@@ -1234,7 +1449,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees-release.git
-      version: 2.0.6-1
+      version: 2.0.12-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees.git
@@ -1249,7 +1464,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_js-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_js.git
@@ -1264,7 +1479,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros-release.git
-      version: 2.0.4-1
+      version: 2.0.10-1
     source:
       test_pull_requests: true
       type: git
@@ -1280,7 +1495,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_interfaces-release.git
-      version: 2.0.2-1
+      version: 2.0.3-2
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_interfaces.git
@@ -1311,7 +1526,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/stonier/py_trees_ros_viewer-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/splintered-reality/py_trees_ros_viewer.git
@@ -1385,7 +1600,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_abi: true
       test_pull_requests: true
@@ -1451,7 +1666,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_pull_requests: true
       type: git
@@ -1467,7 +1682,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 0.8.3-1
+      version: 0.8.4-1
     source:
       test_abi: true
       test_pull_requests: true
@@ -1525,6 +1740,21 @@ repositories:
       type: git
       url: https://github.com/ros2/realtime_support.git
       version: eloquent
+    status: maintained
+  realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: dashing-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 2.0.0-2
+    source:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: dashing-devel
     status: maintained
   resource_retriever:
     doc:
@@ -1681,7 +1911,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros1_bridge-release.git
-      version: 0.8.1-4
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git
@@ -1700,7 +1930,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SteveMacenski/ros2_ouster_drivers-release.git
-      version: 0.0.1-1
+      version: 0.1.0-1
     source:
       test_pull_requests: true
       type: git
@@ -1719,6 +1949,7 @@ repositories:
       - plansys2_executor
       - plansys2_lifecycle_manager
       - plansys2_msgs
+      - plansys2_multidomain_example
       - plansys2_patrol_navigation_example
       - plansys2_pddl_parser
       - plansys2_planner
@@ -1728,7 +1959,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system-release.git
-      version: 0.0.4-1
+      version: 0.0.5-1
     source:
       type: git
       url: https://github.com/IntelligentRoboticsLabs/ros2_planning_system.git
@@ -1784,7 +2015,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.8.6-1
+      version: 0.8.7-1
     source:
       test_pull_requests: true
       type: git
@@ -1895,7 +2126,7 @@ repositories:
       url: https://github.com/ros2-gbp/rosbag2_bag_v2-release.git
       version: 0.0.7-4
     source:
-      test_pull_requests: true
+      test_pull_requests: false
       type: git
       url: https://github.com/ros2/rosbag2_bag_v2.git
       version: master
@@ -1918,7 +2149,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 0.8.1-1
+      version: 0.8.2-1
     source:
       test_pull_requests: true
       type: git
@@ -2136,7 +2367,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_console-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
@@ -2167,7 +2398,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_image_view-release.git
-      version: 1.0.3-1
+      version: 1.0.4-1
     source:
       test_pull_requests: true
       type: git
@@ -2319,7 +2550,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rqt_tf_tree-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git
@@ -2374,13 +2605,52 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 7.0.3-1
+      version: 7.0.4-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros2/rviz.git
       version: eloquent
     status: maintained
+  sick_scan2:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/SICKAG/sick_scan2-release.git
+      version: 0.1.5-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan2.git
+      version: master
+    status: developed
+    status_description: developed
+  slam_toolbox:
+    doc:
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: eloquent-devel
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/SteveMacenski/slam_toolbox-release.git
+      version: 2.1.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/SteveMacenski/slam_toolbox.git
+      version: eloquent-devel
+    status: developed
+  slide_show:
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/slide_show-release.git
+      version: 0.1.0-1
+    source:
+      type: git
+      url: https://github.com/ros2/slide_show.git
+      version: master
+    status: developed
   sophus:
     doc:
       type: git
@@ -2405,7 +2675,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/SteveMacenski/spatio_temporal_voxel_layer-release.git
-      version: 2.1.2-2
+      version: 2.1.3-1
     source:
       test_pull_requests: true
       type: git
@@ -2451,7 +2721,11 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/microROS/system_modes-release.git
-      version: 0.1.5-1
+      version: 0.2.0-3
+    source:
+      type: git
+      url: https://github.com/microROS/system_modes.git
+      version: master
     status: developed
   teleop_tools:
     doc:
@@ -2653,6 +2927,24 @@ repositories:
       url: https://github.com/ros2/urdf.git
       version: eloquent
     status: maintained
+  urdf_parser_py:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    release:
+      packages:
+      - urdfdom_py
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/ros2-gbp/urdfdom_py-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/urdf_parser_py.git
+      version: ros2
+    status: maintained
   urdfdom:
     doc:
       type: git
@@ -2720,6 +3012,37 @@ repositories:
       url: https://github.com/ros2/variants.git
       version: master
     status: maintained
+  velocity_smoother:
+    doc:
+      type: git
+      url: https://github.com/kobuki-base/velocity_smoother.git
+      version: release/0.14.x
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/stonier/velocity_smoother-release.git
+      version: 0.14.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/kobuki-base/velocity_smoother.git
+      version: devel
+    status: maintained
+  vision_msgs:
+    doc:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/eloquent/{package}/{version}
+      url: https://github.com/Kukanani/vision_msgs-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/Kukanani/vision_msgs.git
+      version: ros2
+    status: maintained
   vision_opencv:
     doc:
       type: git
@@ -2733,7 +3056,7 @@ repositories:
       tags:
         release: release/eloquent/{package}/{version}
       url: https://github.com/ros2-gbp/vision_opencv-release.git
-      version: 2.1.3-1
+      version: 2.1.4-1
     source:
       test_pull_requests: true
       type: git

--- a/foxy/distribution.yaml
+++ b/foxy/distribution.yaml
@@ -6,6 +6,38 @@ release_platforms:
   ubuntu:
   - focal
 repositories:
+  ament_cmake:
+    release:
+      packages:
+      - ament_cmake
+      - ament_cmake_auto
+      - ament_cmake_core
+      - ament_cmake_export_definitions
+      - ament_cmake_export_dependencies
+      - ament_cmake_export_include_directories
+      - ament_cmake_export_interfaces
+      - ament_cmake_export_libraries
+      - ament_cmake_export_link_flags
+      - ament_cmake_gmock
+      - ament_cmake_gtest
+      - ament_cmake_include_directories
+      - ament_cmake_libraries
+      - ament_cmake_nose
+      - ament_cmake_pytest
+      - ament_cmake_python
+      - ament_cmake_target_dependencies
+      - ament_cmake_test
+      - ament_cmake_version
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ament_cmake-release.git
+      version: 0.8.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ament/ament_cmake.git
+      version: master
+    status: developed
   ament_package:
     doc:
       type: git
@@ -22,5 +54,30 @@ repositories:
       url: https://github.com/ament/ament_package.git
       version: master
     status: developed
+  googletest:
+    release:
+      packages:
+      - gmock_vendor
+      - gtest_vendor
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/googletest-release.git
+      version: 1.8.9000-1
+    source:
+      type: git
+      url: https://github.com/ament/googletest.git
+      version: ros2
+    status: maintained
+  ros_workspace:
+    release:
+      tags:
+        release: release/foxy/{package}/{version}
+      url: https://github.com/ros2-gbp/ros_workspace-release.git
+      version: 0.8.0-3
+    source:
+      type: git
+      url: https://github.com/ros2/ros_workspace.git
+      version: latest
+    status: maintained
 type: distribution
 version: 2

--- a/index-v4.yaml
+++ b/index-v4.yaml
@@ -18,7 +18,7 @@ distributions:
   crystal:
     distribution: [crystal/distribution.yaml]
     distribution_cache: http://repo.ros2.org/rosdistro_cache/crystal-cache.yaml.gz
-    distribution_status: active
+    distribution_status: end-of-life
     distribution_type: ros2
     python_version: 3
   dashing:

--- a/kinetic/distribution.yaml
+++ b/kinetic/distribution.yaml
@@ -204,7 +204,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/AinsteinAI/ainstein_radar-release.git
-      version: 2.0.2-1
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/AinsteinAI/ainstein_radar.git
@@ -346,11 +346,6 @@ repositories:
       url: https://github.com/pal-robotics/aruco_ros.git
       version: kinetic-devel
     status: developed
-  asr_approx_mvbb:
-    doc:
-      type: git
-      url: https://github.com/asr-ros/asr_approx_mvbb.git
-      version: master
   asr_aruco_marker_recognition:
     doc:
       type: git
@@ -686,7 +681,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.3.1-0
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
@@ -721,16 +716,17 @@ repositories:
       - iirob_filters
       type: git
       url: https://github.com/KITrobotics/ati_force_torque.git
-      version: kinetic-devel
+      version: melodic
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/ati_force_torque-release.git
+      version: 1.1.1-4
     source:
       type: git
       url: https://github.com/KITrobotics/ati_force_torque.git
-      version: kinetic-devel
-    status: developed
+      version: melodic
+    status: maintained
   auction_methods_stack:
     doc:
       type: git
@@ -1269,6 +1265,21 @@ repositories:
       url: https://github.com/ipa320/care-o-bot-release.git
       version: 0.6.7-0
     status: maintained
+  carla_msgs:
+    doc:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/carla-simulator/ros-carla-msgs-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    status: developed
   carla_ros_bridge:
     doc:
       type: git
@@ -1508,7 +1519,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git
@@ -1538,7 +1549,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wew84/cnn_bridge-release.git
-      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/wew84/cnn_bridge.git
@@ -2183,7 +2193,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cpswarm/cpswarm_msgs-release.git
-      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git
@@ -2300,7 +2309,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.12-0
+      version: 1.0.15-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
@@ -2361,7 +2370,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.0.6-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
@@ -2379,11 +2388,10 @@ repositories:
       - dbw_mkz_description
       - dbw_mkz_joystick_demo
       - dbw_mkz_msgs
-      - dbw_mkz_twist_controller
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.2.3-1
+      version: 1.2.7-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git
@@ -2642,11 +2650,7 @@ repositories:
       version: master
     release:
       packages:
-      - doosan_robot
-      - doosan_robotics
-      - dsr_control
       - dsr_description
-      - dsr_example_cpp
       - dsr_example_py
       - dsr_gazebo
       - dsr_launcher
@@ -2884,16 +2888,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/utexas-bwi/eband_local_planner.git
-      version: master
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
-      version: 0.3.1-0
+      version: 0.3.1-2
     source:
       type: git
       url: https://github.com/utexas-bwi/eband_local_planner.git
-      version: master
+      version: kinetic-devel
     status: maintained
   eca_a9:
     doc:
@@ -3213,7 +3217,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.26.0-1
+      version: 9.27.0-1
     source:
       type: git
       url: https://github.com/euslisp/EusLisp.git
@@ -3266,20 +3270,31 @@ repositories:
       packages:
       - exotica
       - exotica_aico_solver
+      - exotica_cartpole_dynamics_solver
       - exotica_collision_scene_fcl
       - exotica_collision_scene_fcl_latest
       - exotica_core
       - exotica_core_task_maps
+      - exotica_ddp_solver
+      - exotica_double_integrator_dynamics_solver
+      - exotica_dynamics_solvers
       - exotica_examples
       - exotica_ik_solver
+      - exotica_ilqg_solver
+      - exotica_ilqr_solver
       - exotica_levenberg_marquardt_solver
+      - exotica_ompl_control_solver
       - exotica_ompl_solver
+      - exotica_pendulum_dynamics_solver
+      - exotica_pinocchio_dynamics_solver
       - exotica_python
+      - exotica_quadrotor_dynamics_solver
+      - exotica_scipy_solver
       - exotica_time_indexed_rrt_connect_solver
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/exotica-release.git
-      version: 5.0.0-0
+      version: 5.1.3-1
     source:
       type: git
       url: https://github.com/ipab-slmc/exotica.git
@@ -3339,7 +3354,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/fanuc.git
-      version: indigo
+      version: kinetic
     release:
       packages:
       - fanuc_cr35ia_support
@@ -3405,7 +3420,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.99-2
+      version: 0.6.0-1
     status: developed
   feed_the_troll:
     doc:
@@ -3587,7 +3602,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
@@ -3678,17 +3693,17 @@ repositories:
       - iirob_filters
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: kinetic-devel
+      version: melodic
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/force_torque_sensor-release.git
-      version: 0.8.1-1
+      version: 1.0.0-2
     source:
       type: git
       url: https://github.com/KITrobotics/force_torque_sensor.git
-      version: kinetic-devel
-    status: developed
+      version: melodic
+    status: maintained
   force_torque_tools:
     doc:
       type: git
@@ -3986,7 +4001,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genlisp.git
-      version: groovy-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/kinetic/{package}/{version}
@@ -3995,7 +4010,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros/genlisp.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   genmsg:
     doc:
@@ -4382,6 +4397,26 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: maintained
+  gundam_robot:
+    doc:
+      type: git
+      url: https://github.com/gundam-global-challenge/gundam_robot.git
+      version: master
+    release:
+      packages:
+      - gundam_robot
+      - gundam_rx78_control
+      - gundam_rx78_description
+      - gundam_rx78_gazebo
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gundam-global-challenge/gundam_robot-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/gundam-global-challenge/gundam_robot.git
+      version: master
+    status: developed
   gx_sound:
     release:
       packages:
@@ -4667,7 +4702,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/heron-release.git
-      version: 0.3.1-0
+      version: 0.3.2-1
     source:
       type: git
       url: https://github.com/heron/heron.git
@@ -5008,6 +5043,28 @@ repositories:
       url: https://github.com/astuff/ibeo_lux.git
       version: release
     status: developed
+  ifm3d:
+    doc:
+      type: git
+      url: https://github.com/ifm/ifm3d-ros.git
+      version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-ros-release.git
+      version: 0.6.2-2
+    source:
+      type: git
+      url: https://github.com/ifm/ifm3d-ros.git
+      version: master
+    status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.17.0-12
+    status: developed
   ifm_o3mxxx:
     doc:
       type: git
@@ -5054,17 +5111,17 @@ repositories:
     doc:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git
-      version: kinetic-devel
+      version: melodic
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/iirob_filters-release.git
-      version: 0.8.1-3
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git
-      version: kinetic-devel
-    status: developed
+      version: melodic
+    status: maintained
   iiwa_stack:
     release:
       packages:
@@ -5467,7 +5524,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/KITrobotics/ipr_extern-release.git
-      version: 0.8.8-0
+      version: 0.9.0-1
     source:
       type: git
       url: https://github.com/KITrobotics/ipr_extern.git
@@ -5482,7 +5539,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/iralabdisco/ira_laser_tools-release.git
-      version: 1.0.2-0
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/iralabdisco/ira_laser_tools.git
@@ -5514,7 +5571,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.2-0
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git
@@ -5648,10 +5705,13 @@ repositories:
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.13-0
+      version: 1.12.14-1
     source:
       test_pull_requests: true
       type: git
@@ -6221,6 +6281,26 @@ repositories:
       url: https://github.com/ros-drivers/kvh_drivers.git
       version: master
     status: maintained
+  kvh_geo_fog_3d:
+    doc:
+      type: git
+      url: https://github.com/MITRE/kvh_geo_fog_3d.git
+      version: master
+    release:
+      packages:
+      - kvh_geo_fog_3d
+      - kvh_geo_fog_3d_driver
+      - kvh_geo_fog_3d_msgs
+      - kvh_geo_fog_3d_rviz
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/MITRE/kvh_geo_fog_3d-release.git
+      version: 1.3.3-1
+    source:
+      type: git
+      url: https://github.com/MITRE/kvh_geo_fog_3d.git
+      version: kinetic-devel
+    status: maintained
   laser_assembler:
     doc:
       type: git
@@ -6400,7 +6480,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros1.git
@@ -6411,7 +6491,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
-      version: 0.0.1-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
@@ -6508,7 +6588,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.31.0-1
+      version: 2.33.1-2
     source:
       test_pull_requests: true
       type: git
@@ -6662,7 +6742,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/lms1xx-release.git
-      version: 0.1.6-0
+      version: 0.1.7-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/lms1xx.git
@@ -6895,7 +6975,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - mapviz
@@ -6910,7 +6990,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     status: developed
   marker_msgs:
     doc:
@@ -7046,7 +7126,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2019.12.30-1
+      version: 2020.3.3-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git
@@ -7082,7 +7162,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.1.7-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git
@@ -7097,7 +7177,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl_msgs-release.git
-      version: 0.1.2-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl_msgs.git
@@ -7131,7 +7211,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/media_export-release.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros/media_export.git
@@ -7568,7 +7648,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit-release.git
-      version: 0.9.17-1
+      version: 0.9.18-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit.git
@@ -7632,7 +7712,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git
@@ -7843,7 +7923,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/NicksSimulationsROS/multi_jackal-release.git
-      version: 0.0.5-0
     source:
       type: git
       url: https://github.com/NicksSimulationsROS/multi_jackal.git
@@ -8215,7 +8294,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.14.5-1
+      version: 1.14.7-1
     source:
       test_commits: false
       test_pull_requests: true
@@ -8351,7 +8430,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.5.1-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git
@@ -8373,7 +8452,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_msgs-release.git
-      version: 0.5.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git
@@ -8422,7 +8501,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git
@@ -9084,7 +9163,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-geographic-info/open_street_map-release.git
-      version: 0.2.4-0
+      version: 0.2.5-1
     source:
       type: git
       url: https://github.com/ros-geographic-info/open_street_map.git
@@ -9374,7 +9453,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod-release.git
-      version: 2.0.2-0
+      version: 2.1.0-1
     source:
       type: git
       url: https://github.com/astuff/pacmod.git
@@ -9389,7 +9468,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod3-release.git
-      version: 1.2.1-0
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/astuff/pacmod3.git
@@ -9404,7 +9483,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/astuff/pacmod_game_control-release.git
-      version: 2.3.0-0
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git
@@ -9799,7 +9878,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
-      version: 2.2.1-2
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git
@@ -9873,7 +9952,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.5.0-1
+      version: 2.6.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
@@ -9919,7 +9998,6 @@ repositories:
       packages:
       - image_exposure_msgs
       - pointgrey_camera_description
-      - pointgrey_camera_driver
       - statistics_msgs
       - wfov_camera_msgs
       tags:
@@ -10539,7 +10617,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.4-0
+      version: 0.3.7-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
@@ -10677,7 +10755,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.11-0
+      version: 0.3.17-1
     source:
       test_pull_requests: true
       type: git
@@ -10904,6 +10982,16 @@ repositories:
       url: https://github.com/raspberrypigibbon/raspigibbon_sim.git
       version: kinetic-devel
     status: developed
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    status: developed
   raspimouse_ros:
     doc:
       type: git
@@ -11045,7 +11133,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_common_msgs-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/roboception/rc_common_msgs.git
@@ -11076,7 +11164,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.2.3-1
+      version: 2.3.3-1
     source:
       test_pull_requests: true
       type: git
@@ -11116,7 +11204,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/roboception-gbp/rcdiscover-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git
@@ -11208,7 +11296,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.11-1
+      version: 2.2.13-1
     source:
       type: git
       url: https://github.com/IntelRealSense/realsense-ros.git
@@ -11254,7 +11342,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.5-1
+      version: 1.12.6-1
     source:
       test_pull_requests: true
       type: git
@@ -11344,7 +11432,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.2.2-0
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git
@@ -11441,7 +11529,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       type: git
       url: https://github.com/mikeferguson/robot_calibration.git
@@ -12319,7 +12407,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.13.3-0
+      version: 0.13.5-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git
@@ -12365,7 +12453,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.13.5-0
+      version: 0.13.6-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
@@ -12376,6 +12464,16 @@ repositories:
       type: git
       url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
       version: master
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/gleichaufjo/ros_cvb_camera_driver_release.git
+      version: 0.0.1-2
+    source:
+      type: git
+      url: https://github.com/gleichaufjo/ros_cvb_camera_driver.git
+      version: master
+    status: maintained
   ros_emacs_utils:
     doc:
       type: git
@@ -12677,7 +12775,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.3-1
+      version: 0.11.4-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -12891,7 +12989,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.21-0
+      version: 1.9.23-1
     source:
       type: git
       url: https://github.com/ros/roslisp.git
@@ -13215,7 +13313,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_console-release.git
-      version: 0.4.8-0
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
@@ -13287,7 +13385,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_image_view-release.git
-      version: 0.4.13-0
+      version: 0.4.14-1
     source:
       test_pull_requests: true
       type: git
@@ -13757,13 +13855,14 @@ repositories:
     release:
       packages:
       - rr_control_input_manager
+      - rr_openrover_description
       - rr_openrover_driver
       - rr_openrover_driver_msgs
       - rr_openrover_stack
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/RoverRobotics-release/rr_openrover_stack-release.git
-      version: 0.7.3-2
+      version: 0.7.4-1
     status: maintained
   rr_swiftnav_piksi:
     doc:
@@ -13974,16 +14073,17 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_pcl-release.git
-      version: 0.1.0-1
+      version: 0.1.0-2
     source:
       type: git
       url: https://github.com/orocos/rtt_pcl.git
+      version: master
+    status: maintained
   rtt_pcl_ros:
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/orocos-gbp/rtt_pcl_ros-release.git
-      version: 0.1.0-1
     source:
       type: git
       url: https://github.com/orocos/rtt_pcl_ros.git
@@ -14137,7 +14237,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 2.0.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git
@@ -14794,6 +14894,12 @@ repositories:
       url: https://github.com/ros-industrial/staubli_experimental.git
       version: kinetic-devel
     status: maintained
+  staubli_val3_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/staubli_val3_driver.git
+      version: master
+    status: maintained
   std_capabilities:
     doc:
       type: git
@@ -14968,7 +15074,6 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cpswarm/swarm_behaviors-release.git
-      version: 1.3.0-1
     source:
       test_pull_requests: true
       type: git
@@ -14981,18 +15086,9 @@ repositories:
       url: https://github.com/cpswarm/swarm_functions.git
       version: kinetic-devel
     release:
-      packages:
-      - area_division
-      - coverage_path
-      - kinematics_exchanger
-      - state_exchanger
-      - swarm_functions
-      - target_monitor
-      - task_allocation
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cpswarm/swarm_functions-release.git
-      version: 1.1.0-1
     source:
       test_pull_requests: true
       type: git
@@ -15000,11 +15096,15 @@ repositories:
       version: kinetic-devel
     status: developed
   swarmros:
+    doc:
+      type: git
+      url: https://github.com/amilankovich-slab/swarmros.git
+      version: master
     release:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/amilankovich-slab/swarmros-release.git
-      version: 0.3.1-2
+      version: 0.3.5-0
     source:
       test_pull_requests: true
       type: git
@@ -15177,7 +15277,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.3.0-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
@@ -15566,7 +15666,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.3.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git
@@ -16344,7 +16444,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git
@@ -16448,7 +16548,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/inomuh/uwb_hardware_driver-release.git
-      version: 0.1.0-1
+      version: 0.1.2-1
     source:
       test_pull_requests: true
       type: git
@@ -16721,7 +16821,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.2.0-3
+      version: 3.3.0-3
     status: maintained
   visp_ros:
     doc:
@@ -16772,7 +16872,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/JdeRobot/VisualStates-release.git
-      version: 0.2.2-0
+      version: 0.2.3-3
     source:
       type: git
       url: https://github.com/JdeRobot/VisualStates.git
@@ -17020,7 +17120,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git

--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -145,7 +145,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/geometry_angles_utils-release.git
-      version: 1.9.11-0
+      version: 1.9.12-1
     source:
       test_pull_requests: true
       type: git
@@ -240,6 +240,163 @@ repositories:
       url: https://github.com/asherikov/ariles-release.git
       version: 1.3.2-1
     status: developed
+  asr_aruco_marker_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_aruco_marker_recognition.git
+      version: master
+  asr_calibration_tool_dome:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_calibration_tool_dome.git
+      version: master
+  asr_cyberglove_lib:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_cyberglove_lib.git
+      version: master
+  asr_cyberglove_visualization:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_cyberglove_visualization.git
+      version: master
+  asr_descriptor_surface_based_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_descriptor_surface_based_recognition.git
+      version: master
+  asr_direct_search_manager:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_direct_search_manager.git
+      version: master
+  asr_fake_object_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_fake_object_recognition.git
+      version: master
+  asr_flir_ptu_controller:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flir_ptu_controller.git
+      version: master
+  asr_flir_ptu_driver:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flir_ptu_driver.git
+      version: master
+  asr_flock_of_birds:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flock_of_birds.git
+      version: master
+  asr_flock_of_birds_tracking:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_flock_of_birds_tracking.git
+      version: master
+  asr_ftc_local_planner:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ftc_local_planner.git
+      version: melodic
+  asr_gazebo_models:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_gazebo_models.git
+      version: master
+  asr_grid_creator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_grid_creator.git
+      version: master
+  asr_halcon_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_halcon_bridge.git
+      version: master
+  asr_intermediate_object_generator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_intermediate_object_generator.git
+      version: master
+  asr_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism.git
+      version: master
+  asr_ism_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ism_visualizations.git
+      version: master
+  asr_ivt:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt.git
+      version: master
+  asr_ivt_bridge:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ivt_bridge.git
+      version: master
+  asr_kinematic_chain_dome:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_kinematic_chain_dome.git
+      version: master
+  asr_kinematic_chain_optimizer:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_kinematic_chain_optimizer.git
+      version: master
+  asr_lib_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_ism.git
+      version: master
+  asr_lib_pose_prediction_ism:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_lib_pose_prediction_ism.git
+      version: master
+  asr_mild_base_driving:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_driving.git
+      version: master
+  asr_mild_base_fake_driving:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_fake_driving.git
+      version: master
+  asr_mild_base_laserscanner:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_laserscanner.git
+      version: master
+  asr_mild_base_launch_files:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_base_launch_files.git
+      version: master
+  asr_mild_calibration_tool:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_calibration_tool.git
+      version: master
+  asr_mild_kinematic_chain:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_kinematic_chain.git
+      version: master
+  asr_mild_navigation:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_mild_navigation.git
+      version: master
   asr_msgs:
     doc:
       type: git
@@ -253,6 +410,119 @@ repositories:
     source:
       type: git
       url: https://github.com/asr-ros/asr_msgs.git
+      version: master
+  asr_navfn:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_navfn.git
+      version: melodic
+  asr_next_best_view:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_next_best_view.git
+      version: melodic
+  asr_object_database:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_object_database.git
+      version: master
+  asr_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm.git
+      version: master
+  asr_psm_visualizations:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_psm_visualizations.git
+      version: master
+  asr_rapidxml:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rapidxml.git
+      version: master
+  asr_recognizer_prediction_ism:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_recognizer_prediction_ism.git
+      version: master
+  asr_recognizer_prediction_psm:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_recognizer_prediction_psm.git
+      version: master
+  asr_relation_graph_generator:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_relation_graph_generator.git
+      version: master
+  asr_resources_for_active_scene_recognition:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_active_scene_recognition.git
+      version: master
+  asr_resources_for_psm:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_psm.git
+      version: master
+  asr_resources_for_vision:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_resources_for_vision.git
+      version: master
+  asr_robot:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_robot.git
+      version: master
+  asr_robot_model_services:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_robot_model_services.git
+      version: melodic
+  asr_ros_uri:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_ros_uri.git
+      version: master
+  asr_rviz_pose_manager:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_rviz_pose_manager.git
+      version: master
+  asr_sick_lms_400:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_sick_lms_400.git
+      version: master
+  asr_state_machine:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_state_machine.git
+      version: master
+  asr_visualization_server:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_visualization_server.git
+      version: master
+  asr_world_model:
+    doc:
+      depends:
+      - asr_msgs
+      type: git
+      url: https://github.com/asr-ros/asr_world_model.git
+      version: master
+  asr_xsd2cpp:
+    doc:
+      type: git
+      url: https://github.com/asr-ros/asr_xsd2cpp.git
       version: master
   astuff_sensor_msgs:
     doc:
@@ -275,7 +545,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/astuff_sensor_msgs-release.git
-      version: 2.3.1-0
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/astuff_sensor_msgs.git
@@ -304,6 +574,22 @@ repositories:
       url: https://github.com/gt-rail-release/async_web_server_cpp-release.git
       version: 0.0.3-0
     status: unmaintained
+  ati_force_torque:
+    doc:
+      type: git
+      url: https://github.com/KITrobotics/ati_force_torque.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KITrobotics/ati_force_torque-release.git
+      version: 1.1.1-3
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KITrobotics/ati_force_torque.git
+      version: melodic
+    status: maintained
   audibot:
     release:
       packages:
@@ -424,6 +710,21 @@ repositories:
       url: https://github.com/aws-robotics/utils-ros1.git
       version: master
     status: maintained
+  axis_camera:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-drivers-gbp/axis_camera-release.git
+      version: 0.3.0-1
+    source:
+      type: git
+      url: https://github.com/ros-drivers/axis_camera.git
+      version: master
+    status: unmaintained
   backward_ros:
     release:
       tags:
@@ -635,6 +936,21 @@ repositories:
       url: https://github.com/osrf/capabilities.git
       version: master
     status: maintained
+  carla_msgs:
+    doc:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/carla-simulator/ros-carla-msgs-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/carla-simulator/ros-carla-msgs.git
+      version: release
+    status: developed
   cartesian_msgs:
     doc:
       type: git
@@ -711,7 +1027,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.20-1
+      version: 0.7.23-1
     source:
       test_pull_requests: true
       type: git
@@ -742,7 +1058,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/locusrobotics/catkin_virtualenv-release.git
-      version: 0.5.1-1
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/locusrobotics/catkin_virtualenv.git
@@ -824,7 +1140,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/cloudwatch_metrics_collector-release.git
-      version: 2.1.1-1
+      version: 2.2.0-1
     source:
       type: git
       url: https://github.com/aws-robotics/cloudwatchmetrics-ros1.git
@@ -855,7 +1171,6 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wew84/cnn_bridge-release.git
-      version: 0.8.5-1
     source:
       type: git
       url: https://github.com/wew84/cnn_bridge.git
@@ -1334,6 +1649,22 @@ repositories:
       url: https://github.com/ros-gbp/common_tutorials-release.git
       version: 0.1.11-0
     status: maintained
+  control_box_rst:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/control_box_rst-release.git
+      version: 0.0.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/control_box_rst.git
+      version: melodic-devel
+    status: developed
   control_msgs:
     doc:
       type: git
@@ -1353,7 +1684,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -1362,7 +1693,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-controls/control_toolbox.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   convex_decomposition:
     doc:
@@ -1468,7 +1799,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dataspeed_can-release.git
-      version: 1.0.12-0
+      version: 1.0.15-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dataspeed_can.git
@@ -1529,7 +1860,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.0.6-1
+      version: 1.0.9-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git
@@ -1547,11 +1878,10 @@ repositories:
       - dbw_mkz_description
       - dbw_mkz_joystick_demo
       - dbw_mkz_msgs
-      - dbw_mkz_twist_controller
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.2.3-1
+      version: 1.2.7-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git
@@ -1717,7 +2047,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
-      version: 1.6.0-0
+      version: 1.6.1-1
     source:
       test_pull_requests: true
       type: git
@@ -1793,6 +2123,21 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/DynamixelSDK.git
       version: melodic-devel
     status: developed
+  eband_local_planner:
+    doc:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/utexas-bwi-gbp/eband_local_planner-release.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/utexas-bwi/eband_local_planner.git
+      version: master
+    status: maintained
   eca_a9:
     doc:
       type: git
@@ -2018,7 +2363,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/tork-a/euslisp-release.git
-      version: 9.26.0-1
+      version: 9.27.0-1
+    source:
+      type: git
+      url: https://github.com/euslisp/EusLisp.git
+      version: master
     status: developed
   executive_smach:
     doc:
@@ -2067,20 +2416,31 @@ repositories:
       packages:
       - exotica
       - exotica_aico_solver
+      - exotica_cartpole_dynamics_solver
       - exotica_collision_scene_fcl
       - exotica_collision_scene_fcl_latest
       - exotica_core
       - exotica_core_task_maps
+      - exotica_ddp_solver
+      - exotica_double_integrator_dynamics_solver
+      - exotica_dynamics_solvers
       - exotica_examples
       - exotica_ik_solver
+      - exotica_ilqg_solver
+      - exotica_ilqr_solver
       - exotica_levenberg_marquardt_solver
+      - exotica_ompl_control_solver
       - exotica_ompl_solver
+      - exotica_pendulum_dynamics_solver
+      - exotica_pinocchio_dynamics_solver
       - exotica_python
+      - exotica_quadrotor_dynamics_solver
+      - exotica_scipy_solver
       - exotica_time_indexed_rrt_connect_solver
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/exotica-release.git
-      version: 5.0.0-0
+      version: 5.1.3-3
     source:
       type: git
       url: https://github.com/ipab-slmc/exotica.git
@@ -2135,7 +2495,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/fanuc.git
-      version: indigo
+      version: kinetic
     source:
       test_commits: false
       type: git
@@ -2174,7 +2534,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/wxmerkt/fcl_catkin-release.git
-      version: 0.5.99-1
+      version: 0.6.0-1
     status: developed
   fetch_gazebo:
     release:
@@ -2408,7 +2768,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/FlexBE/flexbe_behavior_engine-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/team-vigir/flexbe_behavior_engine.git
@@ -2455,11 +2815,27 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/boschresearch/fmi_adapter-release.git
-      version: 1.0.2-0
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/boschresearch/fmi_adapter.git
       version: master
+    status: maintained
+  force_torque_sensor:
+    doc:
+      type: git
+      url: https://github.com/KITrobotics/force_torque_sensor.git
+      version: melodic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KITrobotics/force_torque_sensor-release.git
+      version: 1.0.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/KITrobotics/force_torque_sensor.git
+      version: melodic
     status: maintained
   four_wheel_steering_msgs:
     doc:
@@ -2555,7 +2931,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/gencpp-release.git
-      version: 0.6.2-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros/gencpp.git
@@ -2590,7 +2966,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/genlisp.git
-      version: groovy-devel
+      version: kinetic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -2600,7 +2976,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genlisp.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   genmsg:
     doc:
@@ -2611,8 +2987,9 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/genmsg-release.git
-      version: 0.5.12-0
+      version: 0.5.15-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
       version: kinetic-devel
@@ -2780,7 +3157,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/swri-robotics-gbp/gps_umd-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
@@ -2896,6 +3273,26 @@ repositories:
       url: https://github.com/borglab/gtsam.git
       version: develop
     status: maintained
+  gundam_robot:
+    doc:
+      type: git
+      url: https://github.com/gundam-global-challenge/gundam_robot.git
+      version: master
+    release:
+      packages:
+      - gundam_robot
+      - gundam_rx78_control
+      - gundam_rx78_description
+      - gundam_rx78_gazebo
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/gundam-global-challenge/gundam_robot-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/gundam-global-challenge/gundam_robot.git
+      version: master
+    status: developed
   h264_encoder_core:
     doc:
       type: git
@@ -3112,6 +3509,21 @@ repositories:
       url: https://github.com/husky/husky.git
       version: melodic-devel
     status: maintained
+  husky_cartographer_navigation:
+    doc:
+      type: git
+      url: https://github.com/husky/husky_cartographer_navigation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/husky_cartographer_navigation-release.git
+      version: 0.0.2-1
+    source:
+      type: git
+      url: https://github.com/husky/husky_cartographer_navigation.git
+      version: melodic-devel
+    status: developed
   ibeo_core:
     doc:
       type: git
@@ -3141,6 +3553,28 @@ repositories:
       type: git
       url: https://github.com/astuff/ibeo_lux.git
       version: release
+    status: developed
+  ifm3d:
+    doc:
+      type: git
+      url: https://github.com/ifm/ifm3d-ros.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-ros-release.git
+      version: 0.6.2-2
+    source:
+      type: git
+      url: https://github.com/ifm/ifm3d-ros.git
+      version: master
+    status: developed
+  ifm3d_core:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ifm/ifm3d-release.git
+      version: 0.17.0-7
     status: developed
   ifopt:
     doc:
@@ -3178,12 +3612,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KITrobotics/iirob_filters-release.git
-      version: 0.8.1-2
+      version: 0.9.1-1
     source:
       type: git
       url: https://github.com/KITrobotics/iirob_filters.git
       version: melodic
-    status: developed
+    status: maintained
   image_common:
     doc:
       type: git
@@ -3223,7 +3657,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/image_pipeline-release.git
-      version: 1.13.0-1
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/ros-perception/image_pipeline.git
@@ -3427,6 +3861,21 @@ repositories:
       url: https://github.com/KITrobotics/ipr_extern.git
       version: kinetic-devel
     status: developed
+  ira_laser_tools:
+    doc:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/iralabdisco/ira_laser_tools-release.git
+      version: 1.0.4-1
+    source:
+      type: git
+      url: https://github.com/iralabdisco/ira_laser_tools.git
+      version: kinetic
+    status: developed
   ivcon:
     doc:
       type: git
@@ -3453,12 +3902,27 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/jackal-release.git
-      version: 0.6.3-1
+      version: 0.6.4-1
     source:
       type: git
       url: https://github.com/jackal/jackal.git
       version: kinetic-devel
     status: maintained
+  jackal_cartographer_navigation:
+    doc:
+      type: git
+      url: https://github.com/jackal/jackal_cartographer_navigation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/jackal_cartographer_navigation-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/jackal/jackal_cartographer_navigation.git
+      version: melodic-devel
+    status: developed
   jackal_desktop:
     doc:
       type: git
@@ -3495,16 +3959,63 @@ repositories:
       url: https://github.com/jackal/jackal_simulator.git
       version: kinetic-devel
     status: maintained
+  jason_ros:
+    doc:
+      type: git
+      url: https://github.com/jason-lang/jason_ros.git
+      version: melodic
+    status: maintained
+  jderobot_assets:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/assets-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/JdeRobot/assets.git
+      version: kinetic-devel
+    status: developed
+  jderobot_color_tuner:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/ColorTuner-release.git
+      version: 0.0.3-6
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/JdeRobot/ColorTuner.git
+      version: master
+  jderobot_drones:
+    release:
+      packages:
+      - drone_wrapper
+      - jderobot_drones
+      - rqt_drone_teleop
+      - rqt_ground_robot_teleop
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/drones-release.git
+      version: 1.3.1-1
+    source:
+      type: git
+      url: https://github.com/JdeRobot/drones.git
+      version: master
+    status: developed
   joint_state_publisher:
     doc:
       type: git
       url: https://github.com/ros/joint_state_publisher.git
       version: kinetic-devel
     release:
+      packages:
+      - joint_state_publisher
+      - joint_state_publisher_gui
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/joint_state_publisher-release.git
-      version: 1.12.13-0
+      version: 1.12.14-1
     source:
       test_pull_requests: true
       type: git
@@ -3852,6 +4363,26 @@ repositories:
       url: https://github.com/yujinrobot-release/kobuki_msgs-release.git
       version: 0.7.0-1
     status: maintained
+  kvh_geo_fog_3d:
+    doc:
+      type: git
+      url: https://github.com/MITRE/kvh_geo_fog_3d.git
+      version: master
+    release:
+      packages:
+      - kvh_geo_fog_3d
+      - kvh_geo_fog_3d_driver
+      - kvh_geo_fog_3d_msgs
+      - kvh_geo_fog_3d_rviz
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/MITRE/kvh_geo_fog_3d-release.git
+      version: 1.3.3-1
+    source:
+      type: git
+      url: https://github.com/MITRE/kvh_geo_fog_3d.git
+      version: melodic-devel
+    status: maintained
   laser_assembler:
     doc:
       type: git
@@ -4026,7 +4557,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/aws-gbp/lex_node-release.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/aws-robotics/lex-ros1.git
@@ -4037,7 +4568,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lgsvl/lgsvl_msgs-release.git
-      version: 0.0.1-0
+      version: 0.0.2-1
     source:
       type: git
       url: https://github.com/lgsvl/lgsvl_msgs.git
@@ -4089,7 +4620,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/librealsense2-release.git
-      version: 2.31.0-3
+      version: 2.33.1-2
     source:
       test_pull_requests: true
       type: git
@@ -4252,7 +4783,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     release:
       packages:
       - mapviz
@@ -4267,7 +4798,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/mapviz.git
-      version: kinetic-devel
+      version: master
     status: developed
   marker_msgs:
     doc:
@@ -4374,7 +4905,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/mavlink/mavlink-gbp-release.git
-      version: 2019.12.30-1
+      version: 2020.3.3-1
     source:
       type: git
       url: https://github.com/mavlink/mavlink-gbp-release.git
@@ -4411,7 +4942,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl-release.git
-      version: 0.1.7-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl.git
@@ -4426,7 +4957,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/mcl_3dl_msgs-release.git
-      version: 0.1.2-0
+      version: 0.2.0-1
     source:
       type: git
       url: https://github.com/at-wat/mcl_3dl_msgs.git
@@ -4461,7 +4992,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/media_export-release.git
-      version: 0.2.0-0
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/ros/media_export.git
@@ -4476,7 +5007,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/message_generation-release.git
-      version: 0.4.0-0
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros/message_generation.git
@@ -4550,6 +5081,21 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-drivers/microstrain_mips.git
+      version: master
+    status: developed
+  mikrotik_swos_tools:
+    doc:
+      type: git
+      url: https://github.com/peci1/mikrotik_swos_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/mikrotik_swos_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/peci1/mikrotik_swos_tools.git
       version: master
     status: developed
   mir_robot:
@@ -4736,7 +5282,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/moveit_resources-release.git
-      version: 0.6.4-0
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros-planning/moveit_resources.git
@@ -4790,6 +5336,26 @@ repositories:
     source:
       type: git
       url: https://github.com/peci1/movie_publisher.git
+      version: melodic-devel
+    status: developed
+  mpc_local_planner:
+    doc:
+      type: git
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
+      version: melodic-devel
+    release:
+      packages:
+      - mpc_local_planner
+      - mpc_local_planner_examples
+      - mpc_local_planner_msgs
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner-release.git
+      version: 0.0.1-2
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/rst-tu-dortmund/mpc_local_planner.git
       version: melodic-devel
     status: developed
   mrpt1:
@@ -4894,6 +5460,21 @@ repositories:
       url: https://github.com/mrpt-ros-pkg/mrpt_slam.git
       version: master
     status: maintained
+  mrt_cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/KIT-MRT/mrt_cmake_modules-release.git
+      version: 1.0.0-1
+    source:
+      type: git
+      url: https://github.com/KIT-MRT/mrt_cmake_modules.git
+      version: master
+    status: developed
   multi_object_tracking_lidar:
     doc:
       type: git
@@ -5054,7 +5635,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/navigation-release.git
-      version: 1.16.3-1
+      version: 1.16.4-1
     source:
       test_pull_requests: true
       type: git
@@ -5190,7 +5771,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation-release.git
-      version: 0.5.1-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation.git
@@ -5212,7 +5793,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/at-wat/neonavigation_msgs-release.git
-      version: 0.5.0-1
+      version: 0.8.0-1
     source:
       type: git
       url: https://github.com/at-wat/neonavigation_msgs.git
@@ -5245,7 +5826,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/nerian-vision/nerian_stereo-release.git
-      version: 3.6.0-1
+      version: 3.7.0-1
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo.git
@@ -5340,7 +5921,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-drivers-gbp/nmea_navsat_driver-release.git
-      version: 0.5.1-0
+      version: 0.5.2-1
     source:
       type: git
       url: https://github.com/ros-drivers/nmea_navsat_driver.git
@@ -5472,7 +6053,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/octomap-release.git
-      version: 1.9.3-1
+      version: 1.9.0-1
     source:
       type: git
       url: https://github.com/OctoMap/octomap.git
@@ -5721,6 +6302,25 @@ repositories:
       url: https://github.com/ROBOTIS-GIT/open_manipulator_with_tb3_simulations.git
       version: melodic-devel
     status: developed
+  open_street_map:
+    doc:
+      type: git
+      url: https://github.com/ros-geographic-info/open_street_map.git
+      version: master
+    release:
+      packages:
+      - osm_cartography
+      - route_network
+      - test_osm
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/ros-geographic-info/open_street_map-release.git
+      version: 0.2.5-1
+    source:
+      type: git
+      url: https://github.com/ros-geographic-info/open_street_map.git
+      version: master
+    status: maintained
   opencv_apps:
     doc:
       type: git
@@ -5914,6 +6514,21 @@ repositories:
       url: https://github.com/allenh1/p2os.git
       version: master
     status: maintained
+  pacmod:
+    doc:
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/astuff/pacmod-release.git
+      version: 2.1.0-1
+    source:
+      type: git
+      url: https://github.com/astuff/pacmod.git
+      version: master
+    status: maintained
   pacmod3:
     doc:
       type: git
@@ -5923,7 +6538,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/pacmod3-release.git
-      version: 1.2.1-0
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/astuff/pacmod3.git
@@ -5938,7 +6553,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/astuff/pacmod_game_control-release.git
-      version: 2.3.0-0
+      version: 3.0.1-1
     source:
       type: git
       url: https://github.com/astuff/pacmod_game_control.git
@@ -6207,7 +6822,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ipab-slmc/pinocchio_catkin-release.git
-      version: 2.2.1-1
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/stack-of-tasks/pinocchio.git
@@ -6232,7 +6847,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 2.5.0-1
+      version: 2.6.2-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git
@@ -6283,6 +6898,16 @@ repositories:
     source:
       type: git
       url: https://github.com/mrpt-ros-pkg/pose_cov_ops.git
+      version: master
+    status: maintained
+  pouco2000:
+    doc:
+      type: git
+      url: https://github.com/PoussPouss/pouco2000.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/PoussPouss/pouco2000.git
       version: master
     status: maintained
   power_msgs:
@@ -6568,7 +7193,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/PilzDE/psen_scan-release.git
-      version: 1.0.2-1
+      version: 1.0.4-1
     source:
       type: git
       url: https://github.com/PilzDE/psen_scan.git
@@ -6676,16 +7301,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/python_qt_binding-release.git
-      version: 0.3.6-2
+      version: 0.4.0-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   qb_chain:
     doc:
@@ -6801,7 +7426,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: kinetic-devel
+      version: melodic-devel
     release:
       packages:
       - qt_dotgraph
@@ -6813,12 +7438,12 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/qt_gui_core-release.git
-      version: 0.3.16-1
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   qt_metapackages:
     release:
@@ -6838,6 +7463,22 @@ repositories:
       url: https://github.com/swri-robotics-gbp/qt_metapackages-release.git
       version: 1.0.1-0
     status: developed
+  qt_ros:
+    release:
+      packages:
+      - qt_build
+      - qt_create
+      - qt_ros
+      - qt_tutorials
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/yujinrobot-release/qt_ros-release.git
+      version: 0.2.10-1
+    source:
+      type: git
+      url: https://github.com/stonier/qt_ros.git
+      version: indigo
+    status: maintained
   quaternion_operation:
     doc:
       type: git
@@ -6952,6 +7593,16 @@ repositories:
       url: https://github.com/ros-planning/random_numbers.git
       version: master
     status: maintained
+  raspimouse_description:
+    doc:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/rt-net/raspimouse_description.git
+      version: master
+    status: developed
   raspimouse_sim:
     doc:
       type: git
@@ -6987,7 +7638,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_common_msgs-release.git
-      version: 0.4.0-1
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/roboception/rc_common_msgs.git
@@ -7018,7 +7669,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rc_genicam_api-release.git
-      version: 2.2.3-1
+      version: 2.3.3-1
     source:
       test_pull_requests: true
       type: git
@@ -7058,7 +7709,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/roboception-gbp/rcdiscover-release.git
-      version: 1.0.0-1
+      version: 1.0.2-1
     source:
       test_pull_requests: true
       type: git
@@ -7100,7 +7751,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/IntelRealSense/realsense-ros-release.git
-      version: 2.2.11-1
+      version: 2.2.13-1
     source:
       test_pull_requests: true
       type: git
@@ -7116,7 +7767,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/realtime_tools-release.git
-      version: 1.15.0-1
+      version: 1.15.1-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
@@ -7131,7 +7782,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/resource_retriever-release.git
-      version: 1.12.5-1
+      version: 1.12.6-1
     source:
       test_pull_requests: true
       type: git
@@ -7183,12 +7834,27 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/clearpath-gbp/ridgeback-release.git
-      version: 0.2.2-2
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/ridgeback/ridgeback.git
       version: kinetic-devel
     status: maintained
+  ridgeback_cartographer_navigation:
+    doc:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_cartographer_navigation.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/clearpath-gbp/ridgeback_cartographer_navigation-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ridgeback/ridgeback_cartographer_navigation.git
+      version: melodic-devel
+    status: developed
   ridgeback_desktop:
     doc:
       type: git
@@ -7307,7 +7973,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/robot_calibration-release.git
-      version: 0.6.1-1
+      version: 0.6.2-1
     source:
       test_pull_requests: true
       type: git
@@ -7343,7 +8009,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cra-ros-pkg/robot_localization-release.git
-      version: 2.6.5-1
+      version: 2.6.6-1
     source:
       test_pull_requests: true
       type: git
@@ -7549,7 +8215,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros-release.git
-      version: 1.14.7-1
+      version: 1.14.8-1
     source:
       test_pull_requests: true
       type: git
@@ -7610,7 +8276,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_comm-release.git
-      version: 1.14.3-0
+      version: 1.14.4-1
     source:
       test_pull_requests: true
       type: git
@@ -7656,7 +8322,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_control-release.git
-      version: 0.15.1-0
+      version: 0.17.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_control.git
@@ -7701,7 +8367,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_controllers-release.git
-      version: 0.15.0-0
+      version: 0.15.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros_controllers.git
@@ -7756,6 +8422,21 @@ repositories:
     source:
       type: git
       url: https://github.com/aws-robotics/monitoringmessages-ros1.git
+      version: master
+    status: maintained
+  ros_numpy:
+    doc:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/eric-wieser/ros_numpy-release.git
+      version: 0.0.3-1
+    source:
+      type: git
+      url: https://github.com/eric-wieser/ros_numpy.git
       version: master
     status: maintained
   ros_pytest:
@@ -7814,7 +8495,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/ros_tutorials-release.git
-      version: 0.9.1-0
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git
@@ -7934,7 +8615,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/RobotWebTools-release/rosbridge_suite-release.git
-      version: 0.11.3-1
+      version: 0.11.4-1
     source:
       type: git
       url: https://github.com/RobotWebTools/rosbridge_suite.git
@@ -8067,7 +8748,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/roslisp-release.git
-      version: 1.9.22-0
+      version: 1.9.24-1
     source:
       type: git
       url: https://github.com/ros/roslisp.git
@@ -8128,7 +8809,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rospack-release.git
-      version: 2.5.4-1
+      version: 2.5.5-1
     source:
       test_pull_requests: true
       type: git
@@ -8318,7 +8999,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt-release.git
-      version: 0.5.0-0
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git
@@ -8393,7 +9074,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_console-release.git
-      version: 0.4.8-0
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_console.git
@@ -8454,13 +9135,28 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/rqt_image_view-release.git
-      version: 0.4.13-0
+      version: 0.4.14-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/rqt_image_view.git
       version: master
     status: maintained
+  rqt_joint_trajectory_plot:
+    doc:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot-release.git
+      version: 0.0.5-1
+    source:
+      type: git
+      url: https://github.com/tork-a/rqt_joint_trajectory_plot.git
+      version: master
+    status: developed
   rqt_launch:
     doc:
       type: git
@@ -9011,7 +9707,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SBG-Systems/sbg_ros_driver-release.git
-      version: 2.0.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/SBG-Systems/sbg_ros_driver.git
@@ -9262,10 +9958,13 @@ repositories:
       url: https://github.com/SteveMacenski/slam_toolbox.git
       version: melodic-devel
     release:
+      packages:
+      - slam_toolbox
+      - slam_toolbox_msgs
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/SteveMacenski/slam_toolbox-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       test_pull_requests: true
       type: git
@@ -9304,8 +10003,9 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/sparse_bundle_adjustment-release.git
-      version: 0.4.2-0
+      version: 0.4.3-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros-perception/sparse_bundle_adjustment.git
       version: melodic-devel
@@ -9413,6 +10113,12 @@ repositories:
       type: git
       url: https://github.com/ros-industrial/staubli_experimental.git
       version: kinetic-devel
+    status: maintained
+  staubli_val3_driver:
+    doc:
+      type: git
+      url: https://github.com/ros-industrial/staubli_val3_driver.git
+      version: master
     status: maintained
   std_capabilities:
     doc:
@@ -9535,7 +10241,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: melodic-devel
+      version: kinetic-devel
     release:
       packages:
       - joy_teleop
@@ -9546,11 +10252,11 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/teleop_tools-release.git
-      version: 0.3.0-0
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/ros-teleop/teleop_tools.git
-      version: melodic-devel
+      version: kinetic-devel
     status: maintained
   teleop_twist_joy:
     doc:
@@ -9625,6 +10331,21 @@ repositories:
       url: https://github.com/Terabee/teraranger_array.git
       version: master
     status: maintained
+  tf2_server:
+    doc:
+      type: git
+      url: https://github.com/peci1/tf2_server.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/tf2_server-release.git
+      version: 1.0.5-1
+    source:
+      type: git
+      url: https://github.com/peci1/tf2_server.git
+      version: master
+    status: developed
   tf2_web_republisher:
     doc:
       type: git
@@ -9684,7 +10405,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://gitlab.com/toposens/public/toposens-release.git
-      version: 1.3.0-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://gitlab.com/toposens/public/ros-packages.git
@@ -10065,12 +10786,27 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/KumarRobotics/ublox-release.git
-      version: 1.2.0-1
+      version: 1.3.0-1
     source:
       type: git
       url: https://github.com/KumarRobotics/ublox.git
       version: master
     status: maintained
+  ubnt_airos_tools:
+    doc:
+      type: git
+      url: https://github.com/peci1/ubnt_airos_tools.git
+      version: master
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/peci1/ubnt_airos_tools-release.git
+      version: 1.0.1-1
+    source:
+      type: git
+      url: https://github.com/peci1/ubnt_airos_tools.git
+      version: master
+    status: developed
   um6:
     doc:
       type: git
@@ -10152,7 +10888,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urdf-release.git
-      version: 1.13.1-0
+      version: 1.13.2-1
     source:
       test_pull_requests: true
       type: git
@@ -10219,7 +10955,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/ros-gbp/urdfdom_py-release.git
-      version: 0.4.1-2
+      version: 0.4.2-1
     source:
       test_pull_requests: true
       type: git
@@ -10265,7 +11001,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/seqsense/urg_stamped-release.git
-      version: 0.0.3-1
+      version: 0.0.4-1
     source:
       type: git
       url: https://github.com/seqsense/urg_stamped.git
@@ -10541,7 +11277,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/lagadic/visp-release.git
-      version: 3.2.0-1
+      version: 3.3.0-3
     status: maintained
   visualization_osg:
     release:
@@ -10583,6 +11319,12 @@ repositories:
       url: https://github.com/ros-visualization/visualization_tutorials.git
       version: kinetic-devel
     status: maintained
+  visualstates:
+    release:
+      tags:
+        release: release/melodic/{package}/{version}
+      url: https://github.com/JdeRobot/VisualStates-release.git
+      version: 0.2.3-3
   volksbot_driver:
     doc:
       type: git
@@ -10780,7 +11522,7 @@ repositories:
       tags:
         release: release/melodic/{package}/{version}
       url: https://github.com/cyberbotics/webots_ros-release.git
-      version: 2.0.5-1
+      version: 2.0.6-1
     source:
       type: git
       url: https://github.com/cyberbotics/webots_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -6,11 +6,23 @@ release_platforms:
   debian:
   - buster
   fedora:
-  - '30'
+  - '32'
   ubuntu:
   - focal
 repositories:
   actionlib:
+    doc:
+      type: git
+      url: https://github.com/ros/actionlib.git
+      version: noetic-devel
+    release:
+      packages:
+      - actionlib
+      - actionlib_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/actionlib-release.git
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git
@@ -18,6 +30,15 @@ repositories:
       version: noetic-devel
     status: maintained
   angles:
+    doc:
+      type: git
+      url: https://github.com/ros/angles.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry_angles_utils-release.git
+      version: 1.9.13-1
     source:
       test_pull_requests: true
       type: git
@@ -25,35 +46,85 @@ repositories:
       version: master
     status: maintained
   bond_core:
+    doc:
+      type: git
+      url: https://github.com/ros/bond_core.git
+      version: kinetic-devel
+    release:
+      packages:
+      - bond
+      - bond_core
+      - bondcpp
+      - bondpy
+      - smclib
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/bond_core-release.git
+      version: 1.8.4-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/bond_core.git
       version: kinetic-devel
+    status: maintained
+  capabilities:
+    doc:
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/capabilities-release.git
+      version: 0.3.1-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/osrf/capabilities.git
+      version: master
+    status: maintained
   catkin:
     doc:
       type: git
       url: https://github.com/ros/catkin.git
-      version: kinetic-devel
+      version: noetic-devel
     release:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-gbp/catkin-release.git
-      version: 0.7.20-0
+      version: 0.8.1-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/catkin.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   class_loader:
+    doc:
+      type: git
+      url: https://github.com/ros/class_loader.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/class_loader-release.git
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/class_loader.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   cmake_modules:
+    doc:
+      type: git
+      url: https://github.com/ros/cmake_modules.git
+      version: 0.5-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/cmake_modules-release.git
+      version: 0.5.0-1
     source:
       test_pull_requests: true
       type: git
@@ -61,6 +132,26 @@ repositories:
       version: 0.4-devel
     status: maintained
   common_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/common_msgs.git
+      version: jade-devel
+    release:
+      packages:
+      - actionlib_msgs
+      - common_msgs
+      - diagnostic_msgs
+      - geometry_msgs
+      - nav_msgs
+      - sensor_msgs
+      - shape_msgs
+      - stereo_msgs
+      - trajectory_msgs
+      - visualization_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/common_msgs-release.git
+      version: 1.12.7-1
     source:
       test_pull_requests: true
       type: git
@@ -68,12 +159,30 @@ repositories:
       version: jade-devel
     status: maintained
   control_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/control_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/control_msgs-release.git
+      version: 1.5.2-1
     source:
       type: git
       url: https://github.com/ros-controls/control_msgs.git
       version: kinetic-devel
     status: maintained
   dynamic_reconfigure:
+    doc:
+      type: git
+      url: https://github.com/ros/dynamic_reconfigure.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/dynamic_reconfigure-release.git
+      version: 1.7.0-1
     source:
       test_pull_requests: true
       type: git
@@ -81,6 +190,15 @@ repositories:
       version: noetic-devel
     status: maintained
   eigen_stl_containers:
+    doc:
+      type: git
+      url: https://github.com/ros/eigen_stl_containers.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/eigen_stl_containers-release.git
+      version: 0.1.8-1
     source:
       test_pull_requests: true
       type: git
@@ -88,11 +206,20 @@ repositories:
       version: master
     status: maintained
   filters:
+    doc:
+      type: git
+      url: https://github.com/ros/filters.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/filters-release.git
+      version: 1.9.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/filters.git
-      version: lunar-devel
+      version: noetic-devel
     status: maintained
   four_wheel_steering_msgs:
     source:
@@ -101,37 +228,88 @@ repositories:
       version: master
     status: maintained
   gencpp:
+    doc:
+      type: git
+      url: https://github.com/ros/gencpp.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/gencpp-release.git
+      version: 0.6.5-1
     source:
       type: git
       url: https://github.com/ros/gencpp.git
       version: kinetic-devel
     status: maintained
   geneus:
+    doc:
+      type: git
+      url: https://github.com/jsk-ros-pkg/geneus.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/geneus-release.git
+      version: 3.0.0-1
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/geneus.git
       version: master
     status: maintained
   genlisp:
+    doc:
+      type: git
+      url: https://github.com/ros/genlisp.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/genlisp-release.git
+      version: 0.4.18-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/genlisp.git
-      version: groovy-devel
+      version: kinetic-devel
     status: maintained
   genmsg:
+    doc:
+      type: git
+      url: https://github.com/ros/genmsg.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/genmsg-release.git
+      version: 0.5.15-1
     source:
+      test_pull_requests: true
       type: git
       url: https://github.com/ros/genmsg.git
       version: kinetic-devel
     status: maintained
   gennodejs:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/sloretz/gennodejs-release.git
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/RethinkRobotics-opensource/gennodejs.git
       version: kinetic-devel
     status: maintained
   genpy:
+    doc:
+      type: git
+      url: https://github.com/ros/genpy.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/genpy-release.git
+      version: 0.6.10-1
     source:
       test_pull_requests: true
       type: git
@@ -139,13 +317,49 @@ repositories:
       version: kinetic-devel
     status: maintained
   geometry:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry.git
+      version: noetic-devel
+    release:
+      packages:
+      - eigen_conversions
+      - geometry
+      - kdl_conversions
+      - tf
+      - tf_conversions
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry-release.git
+      version: 1.13.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/geometry.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   geometry2:
+    doc:
+      type: git
+      url: https://github.com/ros/geometry2.git
+      version: noetic-devel
+    release:
+      packages:
+      - geometry2
+      - tf2
+      - tf2_bullet
+      - tf2_eigen
+      - tf2_geometry_msgs
+      - tf2_kdl
+      - tf2_msgs
+      - tf2_py
+      - tf2_ros
+      - tf2_sensor_msgs
+      - tf2_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/geometry2-release.git
+      version: 0.7.0-1
     source:
       test_pull_requests: true
       type: git
@@ -153,6 +367,15 @@ repositories:
       version: melodic-devel
     status: maintained
   gl_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/gl_dependency.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/gl_dependency-release.git
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/gl_dependency.git
@@ -182,35 +405,104 @@ repositories:
       url: https://github.com/ros-perception/laser_geometry.git
       version: indigo-devel
     status: maintained
+  media_export:
+    doc:
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/media_export-release.git
+      version: 0.3.0-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: https://github.com/ros/media_export.git
+      version: indigo-devel
+    status: maintained
   message_generation:
+    doc:
+      type: git
+      url: https://github.com/ros/message_generation.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/message_generation-release.git
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros/message_generation.git
       version: kinetic-devel
     status: maintained
   message_runtime:
+    doc:
+      type: git
+      url: https://github.com/ros/message_runtime.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/message_runtime-release.git
+      version: 0.4.13-1
     source:
       type: git
       url: https://github.com/ros/message_runtime.git
       version: kinetic-devel
     status: maintained
   navigation_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/navigation_msgs.git
+      version: ros1
+    release:
+      packages:
+      - map_msgs
+      - move_base_msgs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/navigation_msgs-release.git
+      version: 1.14.0-1
     source:
       type: git
       url: https://github.com/ros-planning/navigation_msgs.git
       version: ros1
     status: maintained
   nodelet_core:
+    doc:
+      type: git
+      url: https://github.com/ros/nodelet_core.git
+      version: noetic-devel
+    release:
+      packages:
+      - nodelet
+      - nodelet_core
+      - nodelet_topic_tools
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/nodelet_core-release.git
+      version: 1.10.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/nodelet_core.git
       version: noetic-devel
-  orocos_kinematics_dynamics:
+    status: maintained
+  octomap_msgs:
+    doc:
+      type: git
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/octomap_msgs-release.git
+      version: 0.3.4-1
     source:
       type: git
-      url: https://github.com/tfoote/orocos_kinematics_dynamics.git
-      version: python3_support
+      url: https://github.com/OctoMap/octomap_msgs.git
+      version: melodic-devel
     status: maintained
   pcl_msgs:
     source:
@@ -220,6 +512,15 @@ repositories:
       version: indigo-devel
     status: maintained
   pluginlib:
+    doc:
+      type: git
+      url: https://github.com/ros/pluginlib.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/pluginlib-release.git
+      version: 1.12.2-1
     source:
       test_pull_requests: true
       type: git
@@ -227,25 +528,68 @@ repositories:
       version: melodic-devel
     status: maintained
   python_qt_binding:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/python_qt_binding.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/python_qt_binding-release.git
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/python_qt_binding.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   qt_gui_core:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qt_gui_core.git
+      version: melodic-devel
+    release:
+      packages:
+      - qt_dotgraph
+      - qt_gui
+      - qt_gui_app
+      - qt_gui_core
+      - qt_gui_cpp
+      - qt_gui_py_common
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/qt_gui_core-release.git
+      version: 0.4.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros-visualization/qt_gui_core.git
-      version: kinetic-devel
+      version: melodic-devel
     status: maintained
   qwt_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/qwt_dependency.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/qwt_dependency-release.git
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/qwt_dependency.git
       version: kinetic-devel
     status: maintained
   random_numbers:
+    doc:
+      type: git
+      url: https://github.com/ros-planning/random_numbers.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/random_numbers-release.git
+      version: 0.3.2-1
     source:
       test_pull_requests: true
       type: git
@@ -253,12 +597,30 @@ repositories:
       version: master
     status: maintained
   realtime_tools:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/realtime_tools.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/realtime_tools-release.git
+      version: 1.16.0-1
     source:
       type: git
       url: https://github.com/ros-controls/realtime_tools.git
       version: melodic-devel
     status: maintained
   resource_retriever:
+    doc:
+      type: git
+      url: https://github.com/ros/resource_retriever.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/resource_retriever-release.git
+      version: 1.12.6-1
     source:
       test_pull_requests: true
       type: git
@@ -273,32 +635,118 @@ repositories:
       version: noetic-devel
     status: maintained
   ros:
+    doc:
+      type: git
+      url: https://github.com/ros/ros.git
+      version: noetic-devel
+    release:
+      packages:
+      - mk
+      - ros
+      - rosbash
+      - rosboost_cfg
+      - rosbuild
+      - rosclean
+      - roscreate
+      - roslang
+      - roslib
+      - rosmake
+      - rosunit
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros-release.git
+      version: 1.15.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros.git
-      version: kinetic-devel
+      version: noetic-devel
     status: maintained
   ros_comm:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_comm.git
+      version: noetic-devel
+    release:
+      packages:
+      - message_filters
+      - ros_comm
+      - rosbag
+      - rosbag_storage
+      - roscpp
+      - rosgraph
+      - roslaunch
+      - roslz4
+      - rosmaster
+      - rosmsg
+      - rosnode
+      - rosout
+      - rosparam
+      - rospy
+      - rosservice
+      - rostest
+      - rostopic
+      - roswtf
+      - topic_tools
+      - xmlrpcpp
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm-release.git
+      version: 1.15.3-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/ros_comm.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   ros_comm_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_comm_msgs.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rosgraph_msgs
+      - std_srvs
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_comm_msgs-release.git
+      version: 1.11.3-1
     source:
       type: git
       url: https://github.com/ros/ros_comm_msgs.git
       version: kinetic-devel
     status: maintained
   ros_environment:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_environment.git
+      version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_environment-release.git
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/ros/ros_environment.git
       version: noetic
     status: maintained
   ros_tutorials:
+    doc:
+      type: git
+      url: https://github.com/ros/ros_tutorials.git
+      version: melodic-devel
+    release:
+      packages:
+      - ros_tutorials
+      - roscpp_tutorials
+      - rospy_tutorials
+      - turtlesim
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/ros_tutorials-release.git
+      version: 0.9.2-1
     source:
       test_pull_requests: true
       type: git
@@ -306,12 +754,26 @@ repositories:
       version: melodic-devel
     status: maintained
   rosbag_migration_rule:
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosbag_migration_rule-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros/rosbag_migration_rule.git
       version: master
     status: maintained
   rosconsole:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole.git
+      version: melodic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole-release.git
+      version: 1.13.15-1
     source:
       test_pull_requests: true
       type: git
@@ -319,6 +781,15 @@ repositories:
       version: melodic-devel
     status: maintained
   rosconsole_bridge:
+    doc:
+      type: git
+      url: https://github.com/ros/rosconsole_bridge.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosconsole_bridge-release.git
+      version: 0.5.4-1
     source:
       test_pull_requests: true
       type: git
@@ -326,11 +797,41 @@ repositories:
       version: kinetic-devel
     status: maintained
   roscpp_core:
+    doc:
+      type: git
+      url: https://github.com/ros/roscpp_core.git
+      version: noetic-devel
+    release:
+      packages:
+      - cpp_common
+      - roscpp_core
+      - roscpp_serialization
+      - roscpp_traits
+      - rostime
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/roscpp_core-release.git
+      version: 0.7.1-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/roscpp_core.git
-      version: kinetic-devel
+      version: noetic-devel
+    status: maintained
+  rosdoc_lite:
+    doc:
+      type: git
+      url: https://github.com/ros-infrastructure/rosdoc_lite.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rosdoc_lite-release.git
+      version: 0.2.10-1
+    source:
+      type: git
+      url: https://github.com/ros-infrastructure/rosdoc_lite.git
+      version: master
     status: maintained
   roslint:
     source:
@@ -339,19 +840,52 @@ repositories:
       version: master
     status: maintained
   roslisp:
+    doc:
+      type: git
+      url: https://github.com/ros/roslisp.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/roslisp-release.git
+      version: 1.9.24-1
     source:
       type: git
       url: https://github.com/ros/roslisp.git
       version: master
     status: maintained
   rospack:
+    doc:
+      type: git
+      url: https://github.com/ros/rospack.git
+      version: noetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rospack-release.git
+      version: 2.6.0-1
     source:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/rospack.git
-      version: melodic-devel
+      version: noetic-devel
     status: maintained
   rqt:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt.git
+      version: kinetic-devel
+    release:
+      packages:
+      - rqt
+      - rqt_gui
+      - rqt_gui_cpp
+      - rqt_gui_py
+      - rqt_py_common
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt-release.git
+      version: 0.5.1-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt.git
@@ -376,6 +910,15 @@ repositories:
       version: master
     status: maintained
   rqt_graph:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_graph.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_graph-release.git
+      version: 0.4.12-1
     source:
       test_pull_requests: true
       type: git
@@ -383,6 +926,15 @@ repositories:
       version: master
     status: maintained
   rqt_logger_level:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_logger_level.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_logger_level-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_logger_level.git
@@ -395,30 +947,75 @@ repositories:
       version: master
     status: maintained
   rqt_plot:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_plot.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_plot-release.git
+      version: 0.4.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_plot.git
       version: master
     status: maintained
   rqt_pose_view:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_pose_view.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_pose_view-release.git
+      version: 0.5.10-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_pose_view.git
       version: master
     status: maintained
   rqt_publisher:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_publisher.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_publisher-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_publisher.git
       version: master
     status: maintained
   rqt_robot_steering:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_robot_steering.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_robot_steering-release.git
+      version: 0.5.11-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_robot_steering.git
       version: master
     status: maintained
   rqt_service_caller:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_service_caller.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_service_caller-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_service_caller.git
@@ -431,30 +1028,78 @@ repositories:
       version: master
     status: maintained
   rqt_topic:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_topic.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_topic-release.git
+      version: 0.4.12-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_topic.git
       version: master
     status: maintained
   rqt_web:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/rqt_web.git
+      version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/rqt_web-release.git
+      version: 0.4.9-1
     source:
       type: git
       url: https://github.com/ros-visualization/rqt_web.git
       version: master
     status: maintained
   std_msgs:
+    doc:
+      type: git
+      url: https://github.com/ros/std_msgs.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/std_msgs-release.git
+      version: 0.5.13-1
     source:
       type: git
       url: https://github.com/ros/std_msgs.git
       version: kinetic-devel
     status: maintained
   urdf:
+    doc:
+      type: git
+      url: https://github.com/ros/urdf.git
+      version: melodic-devel
+    release:
+      packages:
+      - urdf
+      - urdf_parser_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf-release.git
+      version: 1.13.2-1
     source:
       type: git
       url: https://github.com/ros/urdf.git
       version: melodic-devel
     status: maintained
   urdf_geometry_parser:
+    doc:
+      type: git
+      url: https://github.com/ros-controls/urdf_geometry_parser.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/urdf_geometry_parser-release.git
+      version: 0.0.3-1
     source:
       type: git
       url: https://github.com/ros-controls/urdf_geometry_parser.git
@@ -467,6 +1112,15 @@ repositories:
       version: melodic-devel
     status: maintained
   webkit_dependency:
+    doc:
+      type: git
+      url: https://github.com/ros-visualization/webkit_dependency.git
+      version: kinetic-devel
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros-gbp/webkit_dependency-release.git
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-visualization/webkit_dependency.git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -314,6 +314,8 @@ bullet:
   macports: [bullet]
   openembedded: [bullet@meta-ros]
   opensuse: [libbullet]
+  rhel:
+    '7': [bullet-devel]
   ubuntu:
     '*': [libbullet-dev]
     trusty_python3: [libbullet-dev]
@@ -386,6 +388,11 @@ chrony:
   gentoo: [net-misc/chrony]
   opensuse: [chrony]
   ubuntu: [chrony]
+clang:
+  debian: [clang]
+  fedora: [clang]
+  gentoo: [sys-devel/clang]
+  ubuntu: [clang]
 clang-format:
   debian:
     buster: [clang-format]
@@ -444,6 +451,8 @@ coinor-libipopt-dev:
   debian: [coinor-libipopt-dev]
   fedora: [coin-or-CoinUtils-devel]
   gentoo: [sci-libs/ipopt]
+  rhel:
+    '7': [coin-or-CoinUtils-devel]
   ubuntu: [coinor-libipopt-dev]
 coinor-libosi-dev:
   debian: [coinor-libosi-dev]
@@ -669,6 +678,10 @@ eclipse:
     precise: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     quantal: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
     raring: [eclipse, eclipse-platform, eclipse-rcp, eclipse-emf, eclipse-xsd, eclipse-pde]
+ed:
+  debian: [ed]
+  fedora: [ed]
+  ubuntu: [ed]
 eigen:
   alpine: [eigen-dev]
   arch: [eigen3]
@@ -792,6 +805,7 @@ fltk:  # Consider using the libfltk-dev and fluid (fltk runtime) keys instead.
   ubuntu:
     artful: [fluid, libfltk1.3-dev]
     bionic: [fluid, libfltk1.3-dev]
+    focal: [fluid, libfltk1.3-dev]
     lucid: [fluid, libfltk1.1-dev]
     maverick: [fluid, libfltk1.1-dev]
     natty: [fluid, libfltk1.1-dev]
@@ -850,11 +864,16 @@ ftdi-eeprom:
   debian: [ftdi-eeprom]
   fedora: [libftdi-devel, libftdi-c++-devel]
   gentoo: [dev-embedded/ftdi_eeprom]
+  rhel: [libftdi-devel, libftdi-c++-devel]
   ubuntu: [ftdi-eeprom]
 fxload:
   debian: [fxload]
   fedora: [fxload]
   ubuntu: [fxload]
+g++-5-arm-linux-gnueabihf:
+  ubuntu: [g++-5-arm-linux-gnueabihf]
+g++-5-multilib:
+  ubuntu: [g++-5-multilib]
 g++-multilib:
   debian: [g++-multilib]
   fedora: [gcc-c++, glibc-devel, 'glibc-devel(%{__isa_name}-32)', glibc-static, 'glibc-static(%{__isa_name}-32)', libstdc++-devel, 'libstdc++-devel(%{__isa_name}-32)', libstdc++-static, 'libstdc++-static(%{__isa_name}-32)']
@@ -866,6 +885,7 @@ g++-static:
   fedora: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   gentoo: [sys-devel/gcc]
   openembedded: []
+  rhel: [gcc-c++, glibc-devel, glibc-static, libstdc++-devel, libstdc++-static]
   ubuntu: [g++]
 gamin:
   debian: [gamin]
@@ -1109,6 +1129,7 @@ graphicsmagick:
   fedora: [GraphicsMagick-c++-devel]
   gentoo: [virtual/imagemagick-tools]
   macports: [GraphicsMagick]
+  rhel: [GraphicsMagick-c++-devel]
   ubuntu: [libgraphicsmagick++1-dev]
 graphviz:
   alpine: [graphviz]
@@ -1182,9 +1203,11 @@ gstreamer1.0:
   debian: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
   fedora: [gstreamer1]
   gentoo: ['media-libs/gstreamer:1.0']
+  rhel: [gstreamer1]
   ubuntu: [gstreamer1.0-tools, libgstreamer1.0-0, gir1.2-gstreamer-1.0]
 gstreamer1.0-alsa:
   debian: [gstreamer1.0-alsa]
+  rhel: [gstreamer1-plugins-base]
   ubuntu: [gstreamer1.0-alsa]
 gstreamer1.0-libav:
   alpine: [gst-libav]
@@ -1213,6 +1236,7 @@ gstreamer1.0-plugins-good:
   debian: [gstreamer1.0-plugins-good]
   fedora: [gstreamer1-plugins-good]
   gentoo: ['media-libs/gst-plugins-good:1.0']
+  rhel: [gstreamer1-plugins-good]
   ubuntu: [gstreamer1.0-plugins-good, libgstreamer-plugins-good1.0-0]
 gstreamer1.0-plugins-ugly:
   alpine: [gst-plugins-ugly]
@@ -1420,15 +1444,7 @@ java:
     '*': [default-jdk]
     jessie: [openjdk-7-jdk]
     wheezy: [openjdk-7-jdk]
-  fedora:
-    '21': [java-1.8.0-openjdk]
-    '22': [java-1.8.0-openjdk]
-    '23': [java-1.8.0-openjdk]
-    '24': [java-1.8.0-openjdk]
-    beefy: [java-1.7.0-openjdk]
-    heisenbug: [java-1.8.0-openjdk, java-1.7.0-openjdk]
-    schrödinger’s: [java-1.8.0-openjdk, java-1.7.0-openjdk]
-    spherical: [java-1.7.0-openjdk]
+  fedora: [java]
   freebsd: [openjdk6]
   gentoo: [virtual/jdk]
   ubuntu: [default-jdk]
@@ -1489,6 +1505,8 @@ lcov:
   debian: [lcov]
   fedora: [lcov]
   gentoo: [dev-util/lcov]
+  rhel:
+    '7': [lcov]
   ubuntu: [lcov]
 leveldb:
   debian: [libleveldb-dev]
@@ -1591,42 +1609,123 @@ libbluetooth-dev:
   fedora: [bluez-libs-devel]
   gentoo: [net-wireless/bluez-libs]
   ubuntu: [libbluetooth-dev]
+libboost-atomic:
+  debian:
+    buster: [libboost-atomic1.67.0]
+    stretch: [libboost-atomic1.62.0]
+  fedora: [boost-atomic]
+  ubuntu:
+    bionic: [libboost-atomic1.65.1]
+    eoan: [libboost-atomic1.67.0]
+    focal: [libboost-atomic1.71.0]
+    xenial: [libboost-atomic1.58.0]
+libboost-atomic-dev:
+  debian: [libboost-atomic-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-atomic-dev]
+libboost-chrono:
+  debian:
+    buster: [libboost-chrono1.67.0]
+    stretch: [libboost-chrono1.62.0]
+  fedora: [boost-chrono]
+  ubuntu:
+    bionic: [libboost-chrono1.65.1]
+    eoan: [libboost-chrono1.67.0]
+    focal: [libboost-chrono1.71.0]
+    xenial: [libboost-chrono1.58.0]
 libboost-chrono-dev:
   debian: [libboost-chrono-dev]
-  fedora: [boost-chrono]
+  fedora: [boost-devel]
   ubuntu: [libboost-chrono-dev]
+libboost-date-time:
+  debian:
+    buster: [libboost-date-time1.67.0]
+    stretch: [libboost-date-time1.62.0]
+  fedora: [boost-date-time]
+  ubuntu:
+    bionic: [libboost-date-time1.65.1]
+    eoan: [libboost-date-time1.67.0]
+    focal: [libboost-date-time1.71.0]
+    xenial: [libboost-date-time1.58.0]
+libboost-date-time-dev:
+  debian: [libboost-date-time-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-date-time-dev]
+libboost-dev:
+  debian: [libboost-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-dev]
+libboost-filesystem:
+  debian:
+    buster: [libboost-filesystem1.67.0]
+    stretch: [libboost-filesystem1.62.0]
+  fedora: [boost-filesystem]
+  ubuntu:
+    bionic: [libboost-filesystem1.65.1]
+    eoan: [libboost-filesystem1.67.0]
+    focal: [libboost-filesystem1.71.0]
+    xenial: [libboost-filesystem1.58.0]
 libboost-filesystem-dev:
   debian: [libboost-filesystem-dev]
-  fedora: [boost-fileystem]
+  fedora: [boost-devel]
   gentoo: ['dev-libs/boost[python]']
   ubuntu: [libboost-filesystem-dev]
+libboost-iostreams:
+  debian:
+    buster: [libboost-iostreams1.67.0]
+    stretch: [libboost-iostreams1.62.0]
+  fedora: [boost-iostreams]
+  ubuntu:
+    bionic: [libboost-iostreams1.65.1]
+    eoan: [libboost-iostreams1.67.0]
+    focal: [libboost-iostreams1.71.0]
+    xenial: [libboost-iostreams1.58.0]
 libboost-iostreams-dev:
   debian: [libboost-iostreams-dev]
-  fedora: [boost-iostreams]
+  fedora: [boost-devel]
   ubuntu: [libboost-iostreams-dev]
 libboost-program-options:
   debian:
+    buster: [libboost-program-options1.67.0]
     jessie: [libboost-program-options1.55.0]
     stretch: [libboost-program-options1.62.0]
   fedora: [boost-program-options]
+  rhel: [boost-program-options]
   ubuntu:
     bionic: [libboost-program-options1.65.1]
     disco: [libboost-program-options1.67.0]
     eoan: [libboost-program-options1.67.0]
+    focal: [libboost-program-options1.71.0]
     trusty: [libboost-program-options1.55.0]
     xenial: [libboost-program-options1.58.0]
 libboost-program-options-dev:
   debian: [libboost-program-options-dev]
   fedora: [boost-devel]
   openembedded: [boost@openembedded-core]
+  rhel: [boost-devel]
   ubuntu: [libboost-program-options-dev]
 libboost-python:
+  alpine: [boost-python2]
+  debian:
+    buster: [libboost-python1.67.0]
+    jessie: [libboost-python1.55.0]
+    stretch: [libboost-python1.62.0]
+  fedora: [boost-python2-devel, boost-python3-devel]
+  ubuntu:
+    bionic: [libboost-python1.65.1]
+    disco: [libboost-python1.67.0]
+    eoan: [libboost-python1.67.0]
+    focal: [libboost-python1.71.0]
+    trusty: [libboost-python-1.54.0]
+    xenial: [libboost-python-1.58.0]
+libboost-python-dev:
   alpine: [boost-python2]
   debian: [libboost-python-dev]
   fedora: [boost-python2-devel]
   ubuntu: [libboost-python-dev]
 libboost-random:
   debian:
+    buster: [libboost-random1.67.0]
     jessie: [libboost-random1.55.0]
     stretch: [libboost-random1.62.0]
     wheezy: [libboost-random1.49.0]
@@ -1635,19 +1734,62 @@ libboost-random:
     bionic: [libboost-random1.65.1]
     disco: [libboost-random1.67.0]
     eoan: [libboost-random1.67.0]
+    focal: [libboost-random1.71.0]
     precise: [libboost-random1.46.1]
     trusty: [libboost-random1.54.0]
+    xenial: [libboost-random1.58.0]
 libboost-random-dev:
   debian: [libboost-random-dev]
   fedora: [boost-devel]
   ubuntu: [libboost-random-dev]
+libboost-regex:
+  debian:
+    buster: [libboost-regex1.67.0]
+    stretch: [libboost-regex1.62.0]
+  fedora: [boost-regex]
+  ubuntu:
+    bionic: [libboost-regex1.65.1]
+    eoan: [libboost-regex1.67.0]
+    focal: [libboost-regex1.71.0]
+    xenial: [libboost-regex1.58.0]
+libboost-regex-dev:
+  debian: [libboost-regex-dev]
+  fedora: [boost-devel]
+  ubuntu: [libboost-regex-dev]
+libboost-system:
+  debian:
+    buster: [libboost-system1.67.0]
+    stretch: [libboost-system1.62.0]
+  fedora: [boost-system]
+  rhel: [boost-system]
+  ubuntu:
+    bionic: [libboost-system1.65.1]
+    disco: [libboost-system1.67.0]
+    eoan: [libboost-system1.67.0]
+    focal: [libboost-system1.71.0]
+    trusty: [libboost-system1.55.0]
+    xenial: [libboost-system1.58.0]
 libboost-system-dev:
   debian: [libboost-system-dev]
-  fedora: [boost-system]
+  fedora: [boost-devel]
+  rhel: [boost-devel]
   ubuntu: [libboost-system-dev]
+libboost-thread:
+  debian:
+    buster: [libboost-thread1.67.0]
+    stretch: [libboost-thread1.62.0]
+  fedora: [boost-thread]
+  ubuntu:
+    bionic: [libboost-thread1.65.1]
+    disco: [libboost-thread1.67.0]
+    eoan: [libboost-thread1.67.0]
+    focal: [libboost-thread1.71.0]
+    trusty: [libboost-thread1.55.0]
+    xenial: [libboost-thread1.58.0]
 libboost-thread-dev:
   debian: [libboost-thread-dev]
-  fedora: [boost-thread]
+  fedora: [boost-devel]
+  gentoo: ['dev-libs/boost[threads]']
   ubuntu: [libboost-thread-dev]
 libcairo2-dev:
   arch: [cairo]
@@ -1655,6 +1797,7 @@ libcairo2-dev:
   fedora: [cairo-devel]
   gentoo: [x11-libs/cairo]
   openembedded: [cairo@openembedded-core]
+  rhel: [cairo-devel]
   ubuntu: [libcairo2-dev]
 libcap-dev:
   arch: [libcap]
@@ -1675,6 +1818,12 @@ libccd-dev:
   gentoo: [sci-libs/libccd]
   openembedded: [libccd@meta-ros]
   ubuntu: [libccd-dev]
+libcdd-dev:
+  arch: [cddlib]
+  debian: [libcdd-dev]
+  fedora: [cddlib]
+  gentoo: [sci-libs/cddlib]
+  ubuntu: [libcdd-dev]
 libcegui-mk2-dev:
   arch: [cegui]
   debian: [libcegui-mk2-dev]
@@ -1693,6 +1842,8 @@ libceres-dev:
   fedora: [ceres-solver-devel]
   gentoo: ['sci-libs/ceres-solver[sparse,lapack]']
   openembedded: [ceres-solver@meta-oe]
+  rhel:
+    '7': [ceres-solver-devel]
   ubuntu: [libceres-dev]
 libclang-dev:
   arch: [clang]
@@ -1921,6 +2072,7 @@ libfltk-dev:
   ubuntu:
     artful: [libfltk1.3-dev]
     bionic: [libfltk1.3-dev]
+    focal: [libfltk1.3-dev]
     lucid: [libfltk1.1-dev]
     maverick: [libfltk1.1-dev]
     natty: [libfltk1.1-dev]
@@ -1968,7 +2120,14 @@ libftdi-dev:
   debian: [libftdi-dev]
   fedora: [libftdi-devel]
   gentoo: [dev-embedded/libftdi]
+  rhel: [libftdi-devel]
   ubuntu: [libftdi-dev]
+libftdi1-dev:
+  arch: [libftdi]
+  debian: [libftdi1-dev]
+  fedora: [libftdi-devel]
+  gentoo: [dev-embedded/libftdi]
+  ubuntu: [libftdi1-dev]
 libftdipp-dev:
   debian:
     buster: [libftdipp1-dev]
@@ -2039,6 +2198,7 @@ libgeos++-dev:
   debian: [libgeos++-dev]
   fedora: [geos-devel]
   gentoo: [sci-libs/geos]
+  rhel: [geos-devel]
   ubuntu: [libgeos++-dev]
 libgeotiff-dev:
   arch: [libgeotiff]
@@ -2052,6 +2212,8 @@ libgflags-dev:
   fedora: [gflags-devel]
   gentoo: [dev-cpp/gflags]
   openembedded: [gflags@meta-oe]
+  rhel:
+    '7': [gflags-devel]
   ubuntu: [libgflags-dev]
 libgfortran3:
   arch: [gcc-libs]
@@ -2126,10 +2288,13 @@ libgomp1:
   gentoo: [sys-libs/gcc]
   ubuntu: [libgomp1]
 libgoogle-glog-dev:
+  arch: [google-glog]
   debian: [libgoogle-glog-dev]
   fedora: [glog-devel]
   gentoo: [dev-cpp/glog]
   openembedded: [glog@meta-oe]
+  rhel:
+    '7': [glog-devel]
   ubuntu: [libgoogle-glog-dev]
 libgpgme-dev:
   alpine: [gpgme-dev]
@@ -2175,6 +2340,7 @@ libgps:
   fedora: [gpsd-devel]
   gentoo: [sci-geosciences/gpsd]
   opensuse: [gpsd-devel]
+  rhel: [gpsd-devel]
   ubuntu: [libgps-dev]
 libgsl:
   arch: [gsl]
@@ -2338,6 +2504,7 @@ libjpeg:
   ubuntu:
     artful: [libjpeg-dev]
     bionic: [libjpeg-dev]
+    focal: [libjpeg-dev]
     lucid: [libjpeg62-dev]
     maverick: [libjpeg62-dev]
     natty: [libjpeg62-dev]
@@ -2397,12 +2564,18 @@ libkdtree++-dev:
   debian: [libkdtree++-dev]
   fedora: [libkdtree++-devel]
   ubuntu: [libkdtree++-dev]
+libkml-dev:
+  arch: [libkml]
+  debian: [libkml-dev]
+  ubuntu: [libkml-dev]
 liblapack-dev:
   arch: [lapack]
   debian: [liblapack-dev]
   fedora: [lapack-devel]
   gentoo: [virtual/lapack]
   openembedded: [lapack@meta-ros]
+  rhel:
+    '7': [lapack-devel]
   ubuntu: [liblapack-dev]
 liblapacke-dev:
   debian: [liblapacke-dev]
@@ -2581,6 +2754,38 @@ libogg:
   rhel: [libogg-devel]
   slackware: [libogg]
   ubuntu: [libogg-dev]
+libogre:
+  arch: [ogre-1.9]
+  debian:
+    buster: [libogre-1.9.0v5]
+    jessie: [libogre-1.9.0]
+    stretch: [libogre-1.9.0v5]
+    wheezy: [libogre-dev]
+  fedora: [ogre-devel]
+  freebsd: [ogre3d]
+  gentoo: [dev-games/ogre]
+  macports: [ogre]
+  opensuse: [ogre-devel]
+  rhel: [ogre-devel]
+  slackware: [ogre]
+  ubuntu:
+    artful: [libogre-1.9-dev]
+    bionic: [libogre-1.9.0v5]
+    lucid: [libogre-dev]
+    maverick: [libogre-dev]
+    natty: [libogre-dev]
+    oneiric: [libogre-dev]
+    precise: [libogre-dev]
+    quantal: [libogre-dev]
+    raring: [libogre-dev]
+    saucy: [libogre-1.8-dev]
+    trusty: [libogre-1.8-dev]
+    utopic: [libogre-1.9-dev]
+    vivid: [libogre-1.9-dev]
+    wily: [libogre-1.9-dev]
+    xenial: [libogre-1.9.0v5]
+    yakkety: [libogre-1.9-dev]
+    zesty: [libogre-1.9-dev]
 libogre-dev:
   alpine: [ogre-dev]
   arch: [ogre-1.9]
@@ -2651,6 +2856,8 @@ libopenexr-dev:
   debian: [libopenexr-dev]
   fedora: [OpenEXR-devel]
   gentoo: [media-libs/openexr]
+  rhel:
+    '7': [OpenEXR-devel]
   ubuntu: [libopenexr-dev]
 libopenni-dev:
   arch: [openni]
@@ -2721,6 +2928,34 @@ libopenvdb-dev:
   fedora: [openvdb-devel]
   gentoo: [media-gfx/openvdb]
   ubuntu: [libopenvdb-dev, libilmbase-dev]
+liborocos-bfl:
+  debian:
+    '*': [liborocos-bfl0.8]
+    'stretch': null
+  fedora: [orocos-bfl]
+  ubuntu:
+    '*': [liborocos-bfl0.8]
+    'bionic': null
+    'xenial': null
+liborocos-bfl-dev:
+  debian: [liborocos-bfl-dev]
+  fedora: [orocos-bfl-devel]
+  ubuntu: [liborocos-bfl-dev]
+liborocos-kdl:
+  debian:
+    '*': [liborocos-kdl1.4]
+    'stretch': [liborocos-kdl1.3]
+  fedora: [orocos-kdl]
+  gentoo: [sci-libs/orocos_kdl]
+  ubuntu:
+    '*': [liborocos-kdl1.4]
+    'bionic': [liborocos-kdl1.3]
+    'xenial': [liborocos-kdl1.3]
+liborocos-kdl-dev:
+  debian: [liborocos-kdl-dev]
+  fedora: [orocos-kdl-devel]
+  gentoo: [sci-libs/orocos_kdl]
+  ubuntu: [liborocos-kdl-dev]
 libosmesa6-dev:
   arch: [mesa]
   debian: [libosmesa6-dev]
@@ -2736,6 +2971,8 @@ libpcap:
   gentoo: [net-libs/libpcap]
   macports: [libpcap]
   openembedded: [libpcap@openembedded-core]
+  rhel:
+    '7': [libpcap-devel]
   ubuntu: [libpcap0.8-dev]
 libpcl-all:
   alpine: [pcl]
@@ -3222,6 +3459,8 @@ libqtgui4:
   debian: [libqtgui4]
   fedora: [qt-x11]
   gentoo: ['dev-qt/qtgui:4']
+  rhel:
+    '7': [qt-x11]
   ubuntu: [libqtgui4]
 libqtwebkit-dev:
   arch: [qt5-webkit]
@@ -3287,6 +3526,7 @@ libreadline:
   fedora: [readline]
   gentoo: [sys-libs/readline]
   macports: [readline]
+  rhel: [readline]
   ubuntu: [libreadline-dev]
 libreadline-dev:
   alpine: [readline-dev]
@@ -3331,6 +3571,9 @@ libsoqt4-dev:
   fedora: [SoQt-devel]
   gentoo: [media-libs/SoQt]
   ubuntu: [libsoqt4-dev]
+libspatialindex-dev:
+  debian: [libspatialindex-dev]
+  ubuntu: [libspatialindex-dev]
 libspatialite:
   arch: [libspatialite]
   debian:
@@ -3514,6 +3757,7 @@ libtool:
   ubuntu:
     artful: [libtool, libltdl-dev, libtool-bin]
     bionic: [libtool, libltdl-dev, libtool-bin]
+    focal: [libtool, libltdl-dev, libtool-bin]
     lucid: [libtool, libltdl-dev]
     maverick: [libtool, libltdl-dev]
     natty: [libtool, libltdl-dev]
@@ -3650,6 +3894,7 @@ libusb-1.0:
     beefy: [libusb1]
   gentoo: ['virtual/libusb:1']
   opensuse: [libusb-1_0-0]
+  rhel: [libusbx]
   ubuntu: [libusb-1.0-0]
 libusb-1.0-dev:
   alpine: [libusb-dev]
@@ -3671,6 +3916,8 @@ libusb-dev:
   fedora: [libusb-devel]
   gentoo: [virtual/libusb]
   macports: [libusb]
+  rhel:
+    '7': [libusb-devel]
   ubuntu: [libusb-dev]
 libuv-dev:
   debian:
@@ -3979,6 +4226,7 @@ libzmq3-dev:
   fedora: [zeromq-devel]
   gentoo: [net-libs/cppzmq]
   openembedded: [zeromq@meta-oe]
+  rhel: [zeromq-devel]
   ubuntu: [libzmq3-dev]
 libzmqpp-dev:
   ubuntu: [libzmqpp-dev]
@@ -4033,6 +4281,8 @@ log4cplus:
   arch: [log4cplus]
   debian: [liblog4cplus-dev]
   fedora: [log4cplus-devel]
+  rhel:
+    '7': [log4cplus-devel]
   ubuntu: [liblog4cplus-dev]
 log4cxx:
   alpine: [log4cxx-dev]
@@ -4096,10 +4346,12 @@ lua-dev:
   macports: [lua51]
   ubuntu: [liblua5.1-0-dev]
 lua5.2-dev:
+  arch: [lua52]
   debian: [liblua5.2-dev]
   fedora: [lua]
   gentoo: ['dev-lang/lua:5.2']
   openembedded: [lua@meta-oe]
+  rhel: [lua-devel]
   ubuntu: [liblua5.2-dev]
 lz4:
   alpine: [lz4-dev]
@@ -4110,6 +4362,7 @@ lz4:
   gentoo: [app-arch/lz4]
   openembedded: [lz4@openembedded-core]
   opensuse: [lz4]
+  rhel: [lz4-devel]
   slackware: [lz4]
   ubuntu: [liblz4-dev]
 m4:
@@ -4321,6 +4574,9 @@ msgpack:
   fedora: [msgpack-devel]
   gentoo: [dev-libs/msgpack]
   ubuntu: [libmsgpack-dev]
+multistrap:
+  debian: [multistrap]
+  ubuntu: [multistrap]
 muparser:
   debian: [libmuparser-dev]
   fedora: [muParser-devel]
@@ -4497,6 +4753,11 @@ openni-dev:
   fedora: [openni-devel]
   gentoo: [dev-libs/OpenNI]
   ubuntu: [libopenni-dev]
+openocd:
+  debian: [openocd]
+  fedora: [openocd]
+  gentoo: [openocd]
+  ubuntu: [openocd]
 opensplice:
   gentoo: [sci-libs/opensplice]
 openssh-client:
@@ -4701,6 +4962,7 @@ proj:
   freebsd: [proj]
   gentoo: [sci-libs/proj]
   opensuse: [proj]
+  rhel: [proj-devel]
   slackware: [proj]
   ubuntu: [libproj-dev]
 protobuf:
@@ -4742,6 +5004,8 @@ protobuf-dev:
   macports: [protobuf-cpp]
   openembedded: [protobuf@meta-oe]
   opensuse: [protobuf-devel]
+  rhel:
+    '7': [protobuf-devel, protobuf-compiler]
   slackware: [protobuf]
   ubuntu: [libprotobuf-dev, protobuf-compiler, libprotoc-dev]
 ps-engine:
@@ -4855,10 +5119,12 @@ qtmultimedia5-dev:
 qttools5-dev:
   debian: [qttools5-dev]
   fedora: [qt5-qttools-devel]
+  rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev]
 qttools5-dev-tools:
   debian: [qttools5-dev-tools]
   fedora: [qt5-qttools-devel]
+  rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
 r-base:
   debian: [r-base]
@@ -4870,6 +5136,15 @@ r-base-dev:
   fedora: [R-devel]
   gentoo: [dev-lang/R]
   ubuntu: [r-base-dev]
+range-v3:
+  debian:
+    '*': [librange-v3-dev]
+    stretch: null
+  fedora: [range-v3]
+  gentoo: [dev-cpp/range-v3]
+  ubuntu:
+    '*': [librange-v3-dev]
+    xenial: null
 rapidjson-dev:
   alpine: [rapidjson-dev]
   debian: [rapidjson-dev]
@@ -4922,6 +5197,7 @@ rsyslog:
 rti-connext-dds-5.3.1:
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
+    focal: [rti-connext-dds-5.3.1]
     xenial: [rti-connext-dds-5.3.1]
 rtmidi:
   debian: [librtmidi-dev]
@@ -4976,6 +5252,7 @@ sdl:
   gentoo: [media-libs/libsdl]
   macports: [libsdl]
   openembedded: [libsdl@openembedded-core]
+  rhel: [SDL-devel]
   ubuntu: [libsdl1.2-dev]
 sdl-gfx:
   arch: [sdl_gfx]
@@ -4993,6 +5270,8 @@ sdl-image:
   macports: [libsdl_image]
   openembedded: [libsdl-image@meta-oe]
   opensuse: [SDL_image]
+  rhel:
+    '7': [SDL_image-devel]
   ubuntu: [libsdl-image1.2-dev]
 sdl-mixer:
   alpine: [sdl_mixer-dev]
@@ -5164,6 +5443,8 @@ suitesparse:
   gentoo: [sci-libs/suitesparse]
   macports: [SuiteSparse]
   openembedded: [suitesparse-cxsparse@meta-ros, suitesparse-cholmod@meta-ros]
+  rhel:
+    '7': [suitesparse-devel]
   ubuntu: [libsuitesparse-dev]
 supervisor:
   arch: [supervisor]
@@ -5304,6 +5585,7 @@ tbb:
   gentoo: [dev-cpp/tbb]
   macports: [tbb]
   opensuse: [tbb-devel]
+  rhel: [tbb-devel]
   ubuntu: [libtbb-dev]
 tcsh:
   arch: [tcsh]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -263,6 +263,14 @@ libopenni2-dev:
   osx:
     homebrew:
       packages: [openni2]
+liborocos-kdl:
+  osx:
+    homebrew:
+      packages: [orocos-kdl]
+liborocos-kdl-dev:
+  osx:
+    homebrew:
+      packages: [orocos-kdl]
 libpcap:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -154,6 +154,19 @@ gunicorn:
   fedora: [python-gunicorn]
   gentoo: [www-servers/gunicorn]
   ubuntu: [gunicorn]
+gym-pip:
+  debian:
+    pip:
+      packages: [gym]
+  fedora:
+    pip:
+      packages: [gym]
+  osx:
+    pip:
+      packages: [gym]
+  ubuntu:
+    pip:
+      packages: [gym]
 imgaug-pip:
   debian:
     pip:
@@ -831,6 +844,8 @@ python-catkin-pkg:
   osx:
     pip:
       packages: [catkin-pkg]
+  rhel:
+    '7': [python2-catkin_pkg]
   slackware:
     pip:
       packages: [catkin-pkg]
@@ -1436,6 +1451,23 @@ python-fastdtw-pip:
   ubuntu:
     pip:
       packages: [python-fastdtw]
+python-fcl-pip:
+  debian:
+    pip:
+      depends: [libfcl-dev]
+      packages: [python-fcl]
+  fedora:
+    pip:
+      depends: [libfcl-dev]
+      packages: [python-fcl]
+  osx:
+    pip:
+      depends: [libfcl-dev]
+      packages: [python-fcl]
+  ubuntu:
+    pip:
+      depends: [libfcl-dev]
+      packages: [python-fcl]
 python-fcn-pip:
   debian:
     pip:
@@ -2174,6 +2206,9 @@ python-kitchen:
     pip:
       packages: [kitchen]
   ubuntu: [python-kitchen]
+python-kml:
+  debian: [python-kml]
+  ubuntu: [python-kml]
 python-kombu:
   debian: [python-kombu]
   fedora: [python-kombu]
@@ -2861,6 +2896,15 @@ python-pcapy:
   fedora: [pcapy]
   gentoo: [dev-python/pcapy]
   ubuntu: [python-pcapy]
+python-pcg-gazebo-pip:
+  debian:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
+  ubuntu:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
 python-pep8:
   arch: [python2-pep8]
   debian: [pep8]
@@ -3041,6 +3085,7 @@ python-psutil:
   osx:
     pip:
       packages: [psutil]
+  rhel: [python2-psutil]
   slackware: [psutil]
   ubuntu:
     artful: [python-psutil]
@@ -3332,6 +3377,8 @@ python-pyproj:
   osx:
     pip:
       packages: [pyproj]
+  rhel:
+    '7': [pyproj]
   ubuntu: [python-pyproj]
 python-pyqrcode:
   arch: [python2-qrcode]
@@ -4274,6 +4321,8 @@ python-sphinx:
   osx:
     pip:
       packages: [Sphinx]
+  rhel:
+    '7': [python-sphinx]
   ubuntu:
     '*': [python-sphinx]
     trusty_python3: [python3-sphinx]
@@ -4441,6 +4490,19 @@ python-telegram-bot:
   ubuntu:
     pip:
       packages: [python-telegram-bot]
+python-tensorboardX-pip:
+  debian:
+    pip:
+      packages: [tensorboardX]
+  fedora:
+    pip:
+      packages: [tensorboardX]
+  osx:
+    pip:
+      packages: [tensorboardX]
+  ubuntu:
+    pip:
+      packages: [tensorboardX]
 python-tensorflow-gpu-pip:
   debian:
     pip:
@@ -4820,6 +4882,8 @@ python-virtualenv:
   debian: [python-virtualenv]
   fedora: [python-virtualenv]
   gentoo: [dev-python/virtualenv]
+  rhel:
+    '7': [python-virtualenv]
   ubuntu: [python-virtualenv]
 python-visual:
   debian: [python-visual]
@@ -5077,6 +5141,10 @@ python3-asyncssh:
   debian: [python3-asyncssh]
   fedora: [python3-asyncssh]
   ubuntu: [python3-asyncssh]
+python3-autobahn:
+  debian: [python3-autobahn]
+  fedora: [python3-autobahn]
+  ubuntu: [python3-autobahn]
 python3-babeltrace:
   debian: [python3-babeltrace]
   ubuntu: [python3-babeltrace]
@@ -5111,6 +5179,7 @@ python3-bson:
   osx:
     pip:
       packages: [bson]
+  rhel: ['python%{python3_pkgversion}-bson']
   ubuntu: [python3-bson]
 python3-cairo:
   arch: [python-cairo]
@@ -5176,6 +5245,15 @@ python3-dev:
   openembedded: [python3@openembedded-core]
   rhel: ['python%{python3_pkgversion}-devel']
   ubuntu: [python3-dev]
+python3-distutils:
+  debian:
+    '*': [python3-distutils]
+    stretch: null
+  fedora: [python3]
+  gentoo: [dev-lang/python]
+  ubuntu:
+    '*': [python3-distutils]
+    xenial: null
 python3-django:
   debian: [python3-django]
   fedora: [python3-django]
@@ -5197,6 +5275,8 @@ python3-docker:
   arch: [python-docker]
   debian: [python3-docker]
   fedora: [python3-docker]
+  rhel:
+    '7': ['python%{python3_pkgversion}-docker']
   ubuntu: [python3-docker]
 python3-empy:
   alpine: [py3-empy]
@@ -5224,6 +5304,7 @@ python3-flake8:
 python3-future:
   debian: [python3-future]
   fedora: [python3-future]
+  rhel: ['python%{python3_pkgversion}-future']
   ubuntu: [python3-future]
 python3-gitlab:
   debian:
@@ -5262,10 +5343,22 @@ python3-ifcfg:
   rhel: ['python%{python3_pkgversion}-ifcfg']
   ubuntu:
     bionic: [python3-ifcfg]
+    focal: [python3-ifcfg]
 python3-imageio:
   debian: [python3-imageio]
   gentoo: [dev-python/imageio]
   ubuntu: [python3-imageio]
+python3-kitchen:
+  arch: [python-kitchen]
+  debian: [python3-kitchen]
+  fedora: [python3-kitchen]
+  gentoo: [dev-python/kitchen]
+  osx:
+    pip:
+      packages: [kitchen]
+  ubuntu:
+    '*': [python3-kitchen]
+    xenial: null
 python3-lark-parser:
   debian:
     buster: [python3-lark-parser]
@@ -5278,6 +5371,7 @@ python3-lark-parser:
   rhel: ['python%{python3_pkgversion}-lark-parser']
   ubuntu:
     bionic: [python3-lark-parser]
+    focal: [python3-lark]
     xenial: [python3-lark-parser]
 python3-lttng:
   debian: [python3-lttng]
@@ -5288,6 +5382,9 @@ python3-lxml:
   freebsd: [py36-lxml]
   gentoo: [dev-python/lxml]
   openembedded: [python3-lxml@meta-python]
+  osx:
+    pip:
+      packages: [lxml]
   rhel: ['python%{python3_pkgversion}-lxml']
   ubuntu: [python3-lxml]
 python3-matplotlib:
@@ -5363,6 +5460,8 @@ python3-packaging:
   debian: [python3-packaging]
   fedora: [python3-packaging]
   gentoo: [dev-python/packaging]
+  rhel:
+    '7': ['python%{python3_pkgversion}-packaging']
   ubuntu: [python3-packaging]
 python3-pandas:
   debian: [python3-pandas]
@@ -5374,6 +5473,15 @@ python3-paramiko:
   fedora: [python3-paramiko]
   gentoo: [dev-python/paramiko]
   ubuntu: [python3-paramiko]
+python3-pcg-gazebo-pip:
+  debian:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
+  ubuntu:
+    pip:
+      depends: [libspatialindex-dev, geos, pybind11-dev]
+      packages: [pcg-gazebo]
 python3-pep8:
   alpine: [py3-pycodestyle]
   debian:
@@ -5483,6 +5591,15 @@ python3-pygraphviz:
   rhel: ['python%{python3_pkgversion}-pygraphviz']
   slackware: [pygraphviz]
   ubuntu: [python3-pygraphviz]
+python3-pykdl:
+  debian:
+    '*': [python3-pykdl]
+    'bionic': null
+    'xenial': null
+  ubuntu:
+    '*': [python3-pykdl]
+    'bionic': null
+    'xenial': null
 python3-pyparsing:
   arch: [python-pyparsing]
   debian: [python3-pyparsing]
@@ -5521,13 +5638,25 @@ python3-pytest-timeout:
 python3-qt5-bindings:
   alpine: [py3-qt5, py3-sip, py-sip, py-sip-dev]
   arch: [python-pyqt5]
-  debian: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+  debian:
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, qtbase5-dev, shiboken2]
+    jessie: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
+    stretch: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev, qtbase5-dev]
   fedora: [python3-qt5-devel, sip]
   gentoo: [dev-python/PyQt5]
   opensuse: [python3-qt5]
   rhel: ['python%{python3_pkgversion}-qt5-devel']
   slackware: [python3-PyQt5]
-  ubuntu: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+  ubuntu:
+    '*': [libpyside2-dev, libshiboken2-dev, pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-pyside2.qtsvg, python3-sip-dev, shiboken2]
+    artful: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    bionic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    cosmic: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    disco: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    eoan: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    xenial: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    yakkety: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
+    zesty: [pyqt5-dev, python3-pyqt5, python3-pyqt5.qtsvg, python3-sip-dev]
 python3-qt5-bindings-gl:
   debian: [python3-pyqt5.qtopengl]
   fedora: [python3-qt5]
@@ -5538,6 +5667,25 @@ python3-qt5-bindings-webkit:
   fedora: [python3-qt5-webkit]
   gentoo: ['dev-python/PyQt5[webkit]']
   ubuntu: [python3-pyqt5.qtwebkit]
+python3-rafcon-pip:
+  debian:
+    pip:
+      packages: [rafcon]
+  fedora:
+    pip:
+      packages: [rafcon]
+  ubuntu:
+    pip:
+      packages: [rafcon]
+python3-retrying:
+  arch: [python-retrying]
+  debian: [python3-retrying]
+  fedora: [python3-retrying]
+  gentoo: [retrying]
+  osx:
+    pip:
+      packages: [retrying]
+  ubuntu: [python3-retrying]
 python3-rosdep:
   alpine: [py3-rosdep]
   debian: [python3-rosdep]
@@ -5610,6 +5758,10 @@ python3-scp:
   debian: [python3-scp]
   fedora: [python3-scp]
   ubuntu: [python3-scp]
+python3-serial:
+  debian: [python3-serial]
+  fedora: [python3-pyserial]
+  ubuntu: [python3-serial]
 python3-setuptools:
   debian: [python3-setuptools]
   fedora: [python3-setuptools]
@@ -5634,6 +5786,19 @@ python3-sphinx-rtd-theme:
 python3-sqlalchemy:
   debian: [python3-sqlalchemy]
   ubuntu: [python3-sqlalchemy]
+python3-tensorboardX-pip:
+  debian:
+    pip:
+      packages: [tensorboardX]
+  fedora:
+    pip:
+      packages: [tensorboardX]
+  osx:
+    pip:
+      packages: [tensorboardX]
+  ubuntu:
+    pip:
+      packages: [tensorboardX]
 python3-termcolor:
   debian: [python3-termcolor]
   fedora: [python3-termcolor]
@@ -5651,6 +5816,7 @@ python3-tornado:
   osx:
     pip:
       packages: [tornado]
+  rhel: ['python%{python3_pkgversion}-tornado']
   ubuntu: [python3-tornado]
 python3-twisted:
   arch: [python-twisted]
@@ -5678,7 +5844,15 @@ python3-websocket:
   debian: [python3-websocket]
   fedora: [python3-websocket-client]
   gentoo: [dev-python/websocket-client]
+  rhel: ['python%{python3_pkgversion}-websocket-client']
   ubuntu: [python3-websocket]
+python3-west-pip:
+  debian:
+    pip:
+      packages: [west]
+  ubuntu:
+    pip:
+      packages: [west]
 python3-yaml:
   alpine: [py3-yaml]
   debian: [python3-yaml]

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,1 +1,11 @@
-eol_distro_names = ['ardent', 'bouncy', 'groovy', 'hydro', 'indigo', 'jade', 'lunar']
+import os
+
+from rosdistro import get_index
+
+INDEX_V4_YAML = os.path.normpath(os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), '..', 'index-v4.yaml'))
+
+index_v4 = get_index('file://' + os.path.abspath(INDEX_V4_YAML))
+dist_names_v4 = list(sorted(index_v4.distributions.keys()))
+eol_distro_names = [
+    dist_name for dist_name in dist_names_v4 if index_v4.distributions[dist_name]['distribution_status'] == 'end-of-life']


### PR DESCRIPTION
`python-autobahn` rosdep key is required for the latest rosbridge.
https://github.com/seqsense/aports-ros-experimental/issues/163