### PR TITLE
Add non-dev ogre rosdep key for Alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -2776,6 +2776,7 @@ libogg:
   slackware: [libogg]
   ubuntu: [libogg-dev]
 libogre:
+  alpine: [ogre]
   arch: [ogre-1.9]
   debian:
     buster: [libogre-1.9.0v5]


### PR DESCRIPTION
required by the latest melodic