### PR TITLE
Update gmock key for Alpine v3.11 and later

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1120,9 +1120,9 @@ golang-go:
   ubuntu: [golang-go]
 google-mock:
   alpine:
+    '*': [gtest-dev, gmock]
     3.7: [gmock-dev]
     3.8: [gmock-dev]
-    '*': [gtest-dev, gmock]
   arch: [gmock]
   debian: [google-mock]
   fedora: [gmock-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1119,7 +1119,10 @@ golang-go:
   gentoo: [dev-lang/go]
   ubuntu: [golang-go]
 google-mock:
-  alpine: [gmock-dev]
+  alpine:
+    3.7: [gmock-dev]
+    3.8: [gmock-dev]
+    '*': [gtest-dev, gmock]
   arch: [gmock]
   debian: [google-mock]
   fedora: [gmock-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1121,8 +1121,8 @@ golang-go:
 google-mock:
   alpine:
     '*': [gtest-dev, gmock]
-    3.7: [gmock-dev]
-    3.8: [gmock-dev]
+    '3.7': [gmock-dev]
+    '3.8': [gmock-dev]
   arch: [gmock]
   debian: [google-mock]
   fedora: [gmock-devel]


### PR DESCRIPTION
Requires https://github.com/seqsense/aports-ros-experimental/pull/248 to match `major.minor` styled version.

Merge with https://github.com/seqsense/aports-ros-experimental/pull/251