### PR TITLE
Add entry for python3-parameterized

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5828,6 +5828,11 @@ python3-pandas:
   fedora: [python3-pandas]
   gentoo: [dev-python/pandas]
   ubuntu: [python3-pandas]
+python3-parameterized:
+  alpine: [py3-parameterized]
+  debian: [python3-parameterized]
+  fedora: [python3-parameterized]
+  ubuntu: [python3-parameterized]
 python3-paramiko:
   alpine: [py3-paramiko]
   debian: [python3-paramiko]


### PR DESCRIPTION
`python3-parameterized` entry for alpine, debian, fedora and ubuntu.