### PR TITLE
Add entry for python3-protobuf

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5928,6 +5928,11 @@ python3-pkg-resources:
 python3-prometheus-client:
   debian: [python3-prometheus-client]
   ubuntu: [python3-prometheus-client]
+python3-protobuf:
+  alpine: [py3-protobuf]
+  debian: [python3-protobuf]
+  gentoo: [dev-python/protobuf-python]
+  ubuntu: [python3-protobuf]
 python3-psutil:
   alpine: [py3-psutil]
   arch: [python-psutil]


### PR DESCRIPTION
`python3-protobuf` entry for alpine, debian, gentoo and ubuntu.