### PR TITLE
Add python3-serial for Alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6444,6 +6444,7 @@ python3-sense-hat-pip:
     pip:
       packages: [sense-hat]
 python3-serial:
+  alpine: [py3-serial]
   debian: [python3-serial]
   fedora: [python3-pyserial]
   ubuntu: [python3-serial]


### PR DESCRIPTION
Noetic requires python3-serial now.

https://github.com/seqsense/aports-ros-experimental/tree/master/backports/py-serial