### PR TITLE
Add py-future for Alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1676,6 +1676,7 @@ python-funcsigs:
   rhel: [python2-funcsigs]
   ubuntu: [python-funcsigs]
 python-future:
+  alpine: [py2-future]
   debian: [python-future]
   fedora: [python-future]
   gentoo: [dev-python/future]
@@ -5858,6 +5859,7 @@ python3-flask-restplus-pip:
     pip:
       packages: [flask-restplus]
 python3-future:
+  alpine: [py3-future]
   debian: [python3-future]
   fedora: [python3-future]
   gentoo: [dev-python/future]


### PR DESCRIPTION
Some package added a dependency to it.
https://github.com/seqsense/aports-ros-updater/runs/1586258152?check_suite_focus=true#step:4:305