### PR TITLE
Add libpcap entry.

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3575,6 +3575,7 @@ libosmesa6-dev:
   gentoo: ['media-libs/mesa[osmesa]']
   ubuntu: [libosmesa6-dev]
 libpcap:
+  alpine: [libpcap-dev]
   arch:
     pacman:
       packages: [libpcap]


### PR DESCRIPTION
This is required to compile the driver for the RoboSense LiDARs: https://github.com/RoboSense-LiDAR/ros_rslidar/blob/fc4d6f543063b60c67fe9aaf00991428a0031cd4/rslidar_driver/CMakeLists.txt#L22