### PR TITLE
Add entry to python-gst for alpine and python3

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2086,7 +2086,7 @@ python-gst:
     utopic: [python-gst0.10]
     vivid: [python-gst0.10]
 python-gst-1.0:
-  alpine: [py-gst]
+  alpine: [py2-gst]
   debian:
     buster: [python-gst-1.0]
     jessie: [python-gst-1.0]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2086,6 +2086,7 @@ python-gst:
     utopic: [python-gst0.10]
     vivid: [python-gst0.10]
 python-gst-1.0:
+  alpine: [py-gst]
   debian:
     buster: [python-gst-1.0]
     jessie: [python-gst-1.0]
@@ -6170,6 +6171,11 @@ python3-grpcio-testing:
   ubuntu:
     pip:
       packages: [grpcio-testing]
+python3-gst-1.0:
+  alpine: [py3-gst]
+  debian: [python3-gst-1.0]
+  fedora: [python3-gstreamer1]
+  ubuntu: [python3-gst-1.0]
 python3-h5py:
   debian: [python3-h5py]
   fedora: [python3-h5py]


### PR DESCRIPTION
This PR adds the entries to use `gstreamer` with `python/python3`.

References:
- https://packages.debian.org/jessie/python3-gst-1.0
- https://packages.ubuntu.com/xenial/python3-gst-1.0
- https://fedora.pkgs.org/33/fedora-updates-testing-x86_64/python3-gstreamer1-1.18.0-1.fc33.x86_64.rpm.html
- https://pkgs.alpinelinux.org/package/v3.11/community/x86_64/py3-gst
- https://pkgs.alpinelinux.org/package/v3.7/community/x86_64/py2-gst
