### PR TITLE
Add entry to pyusb for alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -7460,6 +7460,7 @@ python3-urllib3:
   gentoo: [dev-python/urllib3]
   ubuntu: [python3-urllib3]
 python3-usb:
+  alpine: [py3-usb]
   debian: [python3-usb]
   gentoo: [dev-python/pyusb]
   openembedded: [python3-pyusb@meta-python]


### PR DESCRIPTION
This PR adds the entry to use `pyusb` with `python3` on alpine.

Reference:
https://pkgs.alpinelinux.org/packages?name=py3-usb&branch=edge