### PR TITLE
Restore some wrong py2 rosdep keys on py3 environments

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -1950,7 +1950,7 @@ python-gevent:
   ubuntu: [python-gevent]
 python-gi:
   alpine:
-    '*': null
+    '*': [py3-gobject3]
     '3.8': [py2-gobject3]
   arch: [python2-gobject]
   debian: [python-gi]
@@ -1959,7 +1959,7 @@ python-gi:
   ubuntu: [python-gi]
 python-gi-cairo:
   alpine:
-    '*': null
+    '*': [py3-gobject3]
     '3.8': [py2-gobject3]
   debian: [python-gi-cairo]
   gentoo: [dev-python/pygobject]
@@ -8880,7 +8880,7 @@ virtualenv:
   ubuntu: [virtualenv]
 wxpython:
   alpine:
-    '*': null
+    '*': [py3-wxpython]
     '3.8': [py2-wxpython]
   arch: [wxpython]
   debian:


### PR DESCRIPTION
https://github.com/seqsense/aports-ros-updater/runs/4618407001?check_suite_focus=true#step:4:318