### PR TITLE
Add python3-xdot python3-wxgtk4.0 python3-gi-cairo for Alpine

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6917,6 +6917,7 @@ python3-gi:
   openembedded: [python3-pygobject@openembedded-core]
   ubuntu: [python3-gi]
 python3-gi-cairo:
+  alpine: [py3-gobject3]
   arch: [python-gobject]
   debian: [python3-gi-cairo]
   fedora: [python3-gobject]
@@ -9358,12 +9359,14 @@ python3-wrapt:
     '8': [python3-wrapt]
   ubuntu: [python3-wrapt]
 python3-wxgtk4.0:
+  alpine: [py3-wxpython]
   debian: [python3-wxgtk4.0]
   fedora: [python3-wxpython4]
   gentoo: [dev-python/wxpython]
   nixos: [python3Packages.wxPython_4_0]
   ubuntu: [python3-wxgtk4.0]
 python3-xdot:
+  alpine: [py3-xdot]
   arch: [xdot]
   debian: [xdot]
   fedora: [python-xdot]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -9366,7 +9366,9 @@ python3-wxgtk4.0:
   nixos: [python3Packages.wxPython_4_0]
   ubuntu: [python3-wxgtk4.0]
 python3-xdot:
-  alpine: [py3-xdot]
+  alpine:
+    '*': [py3-xdot]
+    '3.8': null
   arch: [xdot]
   debian: [xdot]
   fedora: [python-xdot]


### PR DESCRIPTION
https://github.com/seqsense/aports-ros-updater/runs/7716872989?check_suite_focus=true#step:4:330
Some packages have new dependencies to: python3-xdot python3-wxgtk4.0 python3-gi-cairo

Requires https://github.com/seqsense/aports-ros-experimental/pull/678