### PR TITLE
Add python-xdot for Alpine 3.8

### DIFF
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5829,6 +5829,9 @@ python-wxtools:
     '7': [wxPython]
   ubuntu: [python-wxtools]
 python-xdot:
+  alpine:
+    '*': null
+    '3.8': [py2-xdot]
   debian: [xdot]
   fedora: [python-xdot]
   gentoo: [media-gfx/xdot]


### PR DESCRIPTION
https://github.com/seqsense/aports-ros-updater/runs/7720406950?check_suite_focus=true#step:4:335
py2-xdot is required for melodic