### PR TITLE
Add sdl2 packages entries

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7529,6 +7529,7 @@ sdl2:
   rhel: [SDL2-devel]
   ubuntu: [libsdl2-dev]
 sdl2-image:
+  alpine: [sdl2_image-dev]
   debian: [libsdl2-image-dev]
   fedora: [SDL2_image-devel]
   rhel:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7536,6 +7536,7 @@ sdl2-image:
     '7': [SDL2_image-devel]
   ubuntu: [libsdl2-image-dev]
 sdl2-mixer:
+  alpine: [sdl2_mixer-dev]
   debian: [libsdl2-mixer-dev]
   fedora: [SDL2_mixer-devel]
   ubuntu: [libsdl2-mixer-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -448,9 +448,7 @@ pyros-setup-pip:
     pip:
       packages: [pyros-setup]
 pysdl2:
-  alpine:
-    pip:
-      packages: [pysdl2]
+  alpine: [py-pysdl2]
   debian:
     pip:
       packages: [pysdl2]
@@ -458,9 +456,7 @@ pysdl2:
     pip:
       packages: [pysdl2]
 pysdl2-dll:
-  alpine:
-    pip:
-      packages: [pysdl2-dll]
+  alpine: [py-pysdl2-dll]
   debian:
     pip:
       packages: [pysdl2-dll]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -457,6 +457,16 @@ pysdl2:
   ubuntu:
     pip:
       packages: [pysdl2]
+pysdl2-dll:
+  alpine:
+    pip:
+      packages: [pysdl2-dll]
+  debian:
+    pip:
+      packages: [pysdl2-dll]
+  ubuntu:
+    pip:
+      packages: [pysdl2-dll]
 pyside-tools:
   debian: [pyside-tools]
   gentoo: [dev-python/pyside-tools]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -447,6 +447,16 @@ pyros-setup-pip:
   ubuntu:
     pip:
       packages: [pyros-setup]
+pysdl2:
+  alpine:
+    pip:
+      packages: [pysdl2]
+  debian:
+    pip:
+      packages: [pysdl2]
+  ubuntu:
+    pip:
+      packages: [pysdl2]
 pyside-tools:
   debian: [pyside-tools]
   gentoo: [dev-python/pyside-tools]


### PR DESCRIPTION
- Add `alpine` entry for `sdl2-image` and `sdl2-mixer`.
- Add `alpine`, `debian` and `ubuntu` entries for `pysdl2` and `pysdl2-dll`.