### PR TITLE
Add rti-connext-dds-* for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7773,12 +7773,14 @@ rsyslog:
   fedora: [rsyslog]
   ubuntu: [rsyslog]
 rti-connext-dds-5.3.1:
+  alpine: []
   nixos: []
   ubuntu:
     bionic: [rti-connext-dds-5.3.1]
     focal: [rti-connext-dds-5.3.1]
     xenial: [rti-connext-dds-5.3.1]
 rti-connext-dds-6.0.1:
+  alpine: []
   nixos: []
   ubuntu:
     focal: [rti-connext-dds-6.0.1]


### PR DESCRIPTION
`rti-connext-dds` is not available for Alpine but it's needed by `rmw_connextdds` package.

I think this change will fix the error in https://github.com/seqsense/aports-ros-updater/actions/runs/5087292512/jobs/9142525168?pr=70 .

ref: https://docs.ros.org/en/foxy/Installation/DDS-Implementations/Install-Connext-University-Eval.html