### PR TITLE
Disable eoled distro check

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,7 +1,7 @@
 name: Validate rosdistro
 on:
   push:
-    branches: ['alpine-custom-apk']
+    branches: ['master']
   pull_request:
 
 permissions:
@@ -22,8 +22,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Fetch upstream (to enable diff)
       run: |
-        git remote add unittest_upstream_comparison https://github.com/alpine-ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/alpine-ros/rosdistro.git
-        git fetch --no-tags --depth=1 unittest_upstream_comparison alpine-custom-apk
+        git remote add unittest_upstream_comparison https://github.com/ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/ros/rosdistro.git
+        git fetch --no-tags --depth=1 unittest_upstream_comparison master
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -1,7 +1,7 @@
 name: Validate rosdistro
 on:
   push:
-    branches: ['master']
+    branches: ['alpine-custom-apk']
   pull_request:
 
 permissions:
@@ -22,8 +22,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Fetch upstream (to enable diff)
       run: |
-        git remote add unittest_upstream_comparison https://github.com/ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/ros/rosdistro.git
-        git fetch --no-tags --depth=1 unittest_upstream_comparison master
+        git remote add unittest_upstream_comparison https://github.com/alpine-ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/alpine-ros/rosdistro.git
+        git fetch --no-tags --depth=1 unittest_upstream_comparison alpine-custom-apk
     - name: Install Dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -22,7 +22,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Fetch upstream (to enable diff)
       run: |
-        git remote add unittest_upstream_comparison https://github.com/ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/ros/rosdistro.git
+        git remote add unittest_upstream_comparison https://github.com/alpine-ros/rosdistro.git || git remote set-url unittest_upstream_comparison https://github.com/alpine-ros/rosdistro.git
         git fetch --no-tags --depth=1 unittest_upstream_comparison master
     - name: Install Dependencies
       run: |

--- a/scripts/count_rosdistro_packages.py
+++ b/scripts/count_rosdistro_packages.py
@@ -108,7 +108,7 @@ try:
     if os.path.exists(os.path.join(repo_location, '.git')):
         subprocess.check_call('git -C %s fetch' % repo_location, shell=True)
     else:
-        subprocess.check_call('git clone https://github.com/ros/rosdistro.git %s' % repo_location, shell=True)
+        subprocess.check_call('git clone https://github.com/alpine-ros/rosdistro.git %s' % repo_location, shell=True)
         print("Cloned to %s" % repo_location)
 
     commits = get_all_commits(repo_location, FIRST_HASH)

--- a/test/rosdep_repo_check/test_rosdep_repo_check.py
+++ b/test/rosdep_repo_check/test_rosdep_repo_check.py
@@ -58,8 +58,8 @@ def detect_lines(diffstr):
 
 def get_changed_line_numbers():
     UPSTREAM_NAME = 'unittest_upstream_comparison'
-    DIFF_BRANCH = 'master'
-    DIFF_REPO = 'https://github.com/ros/rosdistro.git'
+    DIFF_BRANCH = 'alpine-custom-apk'
+    DIFF_REPO = 'https://github.com/alpine-ros/rosdistro.git'
 
     # See if UPSTREAM_NAME remote is available and use it as it's expected to be setup by CI
     # Otherwise fall back to origin/master

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -56,8 +56,8 @@ from .fold_block import Fold
 # import pprint
 
 UPSTREAM_NAME = 'unittest_upstream_comparison'
-DIFF_BRANCH = 'master'
-DIFF_REPO = 'https://github.com/ros/rosdistro.git'
+DIFF_BRANCH = 'alpine-custom-apk'
+DIFF_REPO = 'https://github.com/alpine-ros/rosdistro.git'
 
 
 TARGET_FILE_BLACKLIST = []

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -56,8 +56,8 @@ from .fold_block import Fold
 # import pprint
 
 UPSTREAM_NAME = 'unittest_upstream_comparison'
-DIFF_BRANCH = 'alpine-custom-apk'
-DIFF_REPO = 'https://github.com/alpine-ros/rosdistro.git'
+DIFF_BRANCH = 'master'
+DIFF_REPO = 'https://github.com/ros/rosdistro.git'
 
 
 TARGET_FILE_BLACKLIST = []

--- a/test/test_url_validity.py
+++ b/test/test_url_validity.py
@@ -346,7 +346,6 @@ def main():
             continue
         with Fold():
             print("verifying diff of file '%s'" % path)
-            is_eol_distro = path in get_eol_distribution_filenames(url)
             data = load_yaml_with_lines(path)
 
             repos = data['repositories']
@@ -362,10 +361,6 @@ def main():
                 errors = check_repo_for_errors(r)
                 detected_errors.extend(["In file '''%s''': " % path + e
                                         for e in errors])
-                if is_eol_distro:
-                    errors = detect_post_eol_release(n, r, lines)
-                    detected_errors.extend(["In file '''%s''': " % path + e
-                                            for e in errors])
 
     for e in detected_errors:
 


### PR DESCRIPTION
As discussed with @at-wat offline, we decided to disable the EOL distribution check and use the default branch of this repository as base to compute the diff.