### PR TITLE
Add card reader packages

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -477,6 +477,12 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
+ccid:
+  alpine: [ccid]
+  debian: [libccid]
+  fedora: [pcsc-lite-ccid]
+  gentoo: [app-crypt/ccid]
+  ubuntu: [libccid]
 cdk:
   debian: [libcdk5]
   fedora: [cdk]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -482,6 +482,7 @@ ccid:
   debian: [libccid]
   fedora: [pcsc-lite-ccid]
   gentoo: [app-crypt/ccid]
+  nixos: [ccid]
   ubuntu: [libccid]
 cdk:
   debian: [libcdk5]


### PR DESCRIPTION
## Package name:

"ccid"

## Package Upstream Source:

https://ccid.apdu.fr/

## Purpose of using this:

CCID is required to use smartcard readers with pcsc packages. 

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/ja/source/sid/ccid
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/focal/libccid
- Fedora: https://packages.fedoraproject.org/
  - https://src.fedoraproject.org/rpms/pcsc-lite-ccid
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/ccid/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/app-crypt/ccid
- macOS: https://formulae.brew.sh/
  - not available
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/community/x86/ccid
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=ccid&from=0&size=50&sort=relevance&type=packages&query=ccid)
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/pcsc-ccid

<!-- DOC_INDEX_TEMPLATE: add package to rosdistro for documentation indexing -->

<!--- Templated for adding a package to be indexed in a rosdistro: http://wiki.ros.org/rosdistro/Tutorials/Indexing%20Your%20ROS%20Repository%20for%20Documentation%20Generation -->

# Please Add This Package to be indexed in the rosdistro.

ROSDISTRO NAME

# The source is here:

http://sourcecode_url

# Checks
 - [ ] All packages have a declared license in the package.xml
 - [ ] This repository has a LICENSE file
 - [ ] This package is expected to build on the submitted rosdistro
