### PR TITLE
added pcsc-lite package to base.yaml

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6997,6 +6997,14 @@ pcre-dev:
   nixos: [pcre]
   rhel: [pcre-devel]
   ubuntu: [libpcre++-dev]
+pcsc-lite:
+  alpine: [pcsc-lite]
+  arch: [pcsclite]
+  debian: [pcsc-lite]
+  fedora: [pcsc-lite]
+  gentoo: [sys-apps/pcsc-lite]
+  nixos: [pcsclite]
+  ubuntu: [pcsc-lite]
 phantomjs:
   debian:
     buster: [phantomjs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7001,8 +7001,8 @@ pcsc-lite:
   alpine: [pcsc-lite]
   arch: [pcsclite]
   debian:
-    bullseye: [pcscd]
     bookworm: [pcsc-lite]
+    bullseye: [pcscd]
   fedora: [pcsc-lite]
   gentoo: [sys-apps/pcsc-lite]
   nixos: [pcsclite]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7000,11 +7000,11 @@ pcre-dev:
 pcsc-lite:
   alpine: [pcsc-lite]
   arch: [pcsclite]
-  debian: [pcsc-lite]
+  debian: [source, https://packages.debian.org/source/bookworm/pcsc-lite]
   fedora: [pcsc-lite]
   gentoo: [sys-apps/pcsc-lite]
   nixos: [pcsclite]
-  ubuntu: [pcsc-lite]
+  ubuntu: [source, https://packages.ubuntu.com/source/focal/pcsc-lite]
 phantomjs:
   debian:
     buster: [phantomjs]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7000,11 +7000,15 @@ pcre-dev:
 pcsc-lite:
   alpine: [pcsc-lite]
   arch: [pcsclite]
-  debian: [source, https://packages.debian.org/source/bookworm/pcsc-lite]
+  debian:
+    bullseye: [pcscd]
+    bookworm: [pcsc-lite]
   fedora: [pcsc-lite]
   gentoo: [sys-apps/pcsc-lite]
   nixos: [pcsclite]
-  ubuntu: [source, https://packages.ubuntu.com/source/focal/pcsc-lite]
+  ubuntu:
+    focal: [pcscd]
+    jammy: [pcscd]
 phantomjs:
   debian:
     buster: [phantomjs]


### PR DESCRIPTION
Please add the following dependency to the rosdep database.

## Package name:

TODO

## Package Upstream Source:

https://pcsclite.apdu.fr/

## Purpose of using this:

includes a pcsc daemon required to manage resources for pcsc-lite

Distro packaging links:

## Links to Distribution Packages

<!-- Replace the REQUIRED areas with the URL to the package.  For IF AVAILABLE areas, either put in the URL to the package or state 'not available'.
More info at https://github.com/ros/rosdistro/blob/master/CONTRIBUTING.md#guidelines-for-rosdep-rules -->

- Debian: https://packages.debian.org/
  - https://packages.debian.org/ja/source/sid/pcsc-lite
- Ubuntu: https://packages.ubuntu.com/
  - https://packages.ubuntu.com/source/focal/pcsc-lite
- Fedora: https://packages.fedoraproject.org/
  - https://packages.fedoraproject.org/pkgs/pcsc-lite/pcsc-lite/
- Arch: https://www.archlinux.org/packages/
  - https://archlinux.org/packages/extra/x86_64/pcsclite/
- Gentoo: https://packages.gentoo.org/
  - https://packages.gentoo.org/packages/sys-apps/pcsc-lite
- macOS: https://formulae.brew.sh/
  - IF AVAILABLE
- Alpine: https://pkgs.alpinelinux.org/packages
  - https://pkgs.alpinelinux.org/package/edge/main/x86/pcsc-lite
- NixOS/nixpkgs: https://search.nixos.org/packages
  - https://search.nixos.org/packages?channel=23.05&show=pcsclite&from=0&size=50&sort=relevance&type=packages&query=pcsc+lite
- openSUSE: https://software.opensuse.org/package/
  - https://software.opensuse.org/package/pcsc-lite
