### PR TITLE
removed ccid as we already have libccid

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -490,13 +490,6 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
-ccid:
-  alpine: [ccid]
-  debian: [libccid]
-  fedora: [pcsc-lite-ccid]
-  gentoo: [app-crypt/ccid]
-  nixos: [ccid]
-  ubuntu: [libccid]
 cdk:
   debian: [libcdk5]
   fedora: [cdk]


### PR DESCRIPTION

For some reason ccid and libccid were included in the rosdistro base.yaml which are both inclusive of the same packages. I have removed ccid so as to keep linccid as per the official ros package listing convention. 