### PR TITLE
removed ccid as we have libccid

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -490,13 +490,6 @@ cccc:
   gentoo: [dev-util/cccc]
   nixos: [cccc]
   ubuntu: [cccc]
-ccid:
-  alpine: [ccid]
-  debian: [libccid]
-  fedora: [pcsc-lite-ccid]
-  gentoo: [app-crypt/ccid]
-  nixos: [ccid]
-  ubuntu: [libccid]
 cdk:
   debian: [libcdk5]
   fedora: [cdk]


### PR DESCRIPTION
removed ccid from rosdep base.yaml as there is libccid that contains the same packages and we want to keep the list int eh same convention as offical ros