### PR TITLE
Merge upstream 20240111

### DIFF
--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1679,7 +1679,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -756,11 +756,11 @@ repositories:
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: humble
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: humble
   bond_core:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.2.0-2
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -714,7 +714,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.3-2
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4554,7 +4554,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
-      version: 4.0.0-1
+      version: 4.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_worlds.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5946,7 +5946,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.0.1-1
+      version: 3.0.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3619,7 +3619,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -3628,7 +3628,7 @@ repositories:
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
-      version: main
+      version: humble
     status: maintained
   microstrain_inertial:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4592,7 +4592,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_navigation_cfg_public-release.git
-      version: 3.0.5-1
+      version: 3.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_navigation_cfg_public.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3176,6 +3176,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git
       version: ros_event_camera
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer-release.git
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -668,6 +668,21 @@ repositories:
       url: https://github.com/wep21/bag2_to_image.git
       version: main
     status: maintained
+  bcr_bot:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros2
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/blackcoffeerobotics/bcr_bot_ros2-release.git
+      version: 1.0.1-3
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros2
+    status: developed
   behaviortree_cpp_v3:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8267,7 +8267,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.5-1
+      version: 4.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3673,35 +3673,6 @@ repositories:
       url: https://github.com/OrebroUniversity/mod.git
       version: master
     status: developed
-  mola:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    release:
-      packages:
-      - mola_common
-      - mola_demos
-      - mola_imu_preintegration
-      - mola_input_euroc_dataset
-      - mola_input_kitti_dataset
-      - mola_input_rawlog
-      - mola_input_ros2
-      - mola_kernel
-      - mola_launcher
-      - mola_test_datasets
-      - mola_viz
-      - mola_yaml
-      - mp2p_icp
-      tags:
-        release: release/humble/{package}/{version}
-      url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.2-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    status: developed
   mola_common:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4940,7 +4940,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_simulation-release.git
-      version: 4.0.4-1
+      version: 4.0.6-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_simulation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4620,7 +4620,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_statistics-release.git
-      version: 2.1.5-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_statistics.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4916,7 +4916,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.5-1
+      version: 3.8.6-3
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2993,7 +2993,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/launch_pal-release.git
-      version: 0.0.8-2
+      version: 0.0.14-1
     source:
       type: git
       url: https://github.com/pal-robotics/launch_pal.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4593,7 +4593,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_hey5-release.git
-      version: 4.0.0-1
+      version: 4.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_hey5.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5938,7 +5938,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.7-1
+      version: 2.1.8-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7355,7 +7355,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8835,7 +8835,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -84,6 +84,11 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros2.git
       version: humble
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_tmcl-release.git
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros2.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8938,7 +8938,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/urdf_test-ros2-gbp.git
-      version: 2.0.1-1
+      version: 2.0.2-1
     source:
       type: git
       url: https://github.com/pal-robotics/urdf_test.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7778,6 +7778,15 @@ repositories:
       type: git
       url: https://github.com/SICKAG/sick_scan_xd.git
       version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/sick_scan_xd-release.git
+      version: 3.1.6-1
+    source:
+      type: git
+      url: https://github.com/SICKAG/sick_scan_xd.git
+      version: master
     status: developed
   sicks300_2:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2392,7 +2392,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: devel
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -2401,7 +2401,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: devel
+      version: main
     status: maintained
   grid_map:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5918,7 +5918,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.1.6-1
+      version: 2.1.7-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4635,7 +4635,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_urdf_utils-release.git
-      version: 2.0.0-1
+      version: 2.0.1-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_urdf_utils.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5857,7 +5857,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.0.3-1
+      version: 3.0.4-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2326,7 +2326,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - gps_msgs
@@ -2341,7 +2341,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   graph_msgs:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8219,7 +8219,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_navigation-release.git
-      version: 4.0.5-1
+      version: 4.0.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_navigation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6356,7 +6356,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 2.29.0-1
+      version: 2.30.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3714,6 +3714,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_common-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -979,7 +979,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4881,7 +4881,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.4-1
+      version: 3.8.5-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8282,7 +8282,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.6-1
+      version: 4.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1683,12 +1683,13 @@ repositories:
       - etsi_its_denm_msgs
       - etsi_its_messages
       - etsi_its_msgs
+      - etsi_its_msgs_utils
       - etsi_its_primitives_conversion
       - etsi_its_rviz_plugins
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
-      version: 1.0.0-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5956,7 +5956,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.0.2-1
+      version: 3.0.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3180,7 +3180,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libcaer-release.git
-      version: 1.1.1-1
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8264,7 +8264,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.27-1
+      version: 4.0.28-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -949,7 +949,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -984,7 +984,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_config-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_config.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7440,7 +7440,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.1-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2502,7 +2502,8 @@ repositories:
       type: git
       url: https://github.com/pal-robotics/hey5_description.git
       version: humble-devel
-    status: maintained
+    status: end-of-life
+    status_description: Deprecated by package pal_hey5_description
   hls_lfcd_lds_driver:
     doc:
       type: git
@@ -4569,6 +4570,25 @@ repositories:
       url: https://github.com/pal-robotics/pal_gripper.git
       version: humble-devel
     status: developed
+  pal_hey5:
+    doc:
+      type: git
+      url: https://github.com/pal-robotics/pal_hey5.git
+      version: humble-devel
+    release:
+      packages:
+      - pal_hey5
+      - pal_hey5_controller_configuration
+      - pal_hey5_description
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/pal-gbp/pal_hey5-release.git
+      version: 4.0.0-1
+    source:
+      type: git
+      url: https://github.com/pal-robotics/pal_hey5.git
+      version: humble-devel
+    status: maintained
   pal_navigation_cfg_public:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4573,7 +4573,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gripper-release.git
-      version: 3.0.4-1
+      version: 3.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gripper.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3693,6 +3693,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7090,6 +7090,12 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: humble
     status: maintained
+  rqt_gauges:
+    source:
+      test_pull_requests: false
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
   rqt_graph:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3792,6 +3792,16 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
+  mp2p_icp:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    status: developed
   mqtt_client:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -694,7 +694,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.2-1
+      version: 4.4.3-2
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3699,6 +3699,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
     status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8257,7 +8257,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_simulation-release.git
-      version: 4.0.3-1
+      version: 4.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_simulation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -512,7 +512,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/aruco_ros-release.git
-      version: 5.0.3-1
+      version: 5.0.4-1
     source:
       type: git
       url: https://github.com/pal-robotics/aruco_ros.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4902,7 +4902,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_navigation-gbp.git
-      version: 4.0.5-1
+      version: 4.0.9-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_navigation.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4922,7 +4922,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pmb2_robot-gbp.git
-      version: 5.0.7-1
+      version: 5.0.15-1
     source:
       type: git
       url: https://github.com/pal-robotics/pmb2_robot.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2710,6 +2710,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: humble
     status: maintained
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_pipeline-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    status: maintained
   imu_tools:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3629,7 +3629,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.1.0-1
+      version: 3.2.0-2
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4284,7 +4284,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - novatel_gps_driver
@@ -4296,7 +4296,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   novatel_oem7_driver:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4158,7 +4158,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git
-      version: master
+      version: default
     release:
       packages:
       - nerian_stereo
@@ -4169,7 +4169,7 @@ repositories:
     source:
       type: git
       url: https://github.com/nerian-vision/nerian_stereo_ros2.git
-      version: master
+      version: default
     status: developed
   network_interface:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4143,7 +4143,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/neobotix/neo_simulation2.git
-      version: main
+      version: humble
     release:
       tags:
         release: release/humble/{package}/{version}
@@ -4152,7 +4152,7 @@ repositories:
     source:
       type: git
       url: https://github.com/neobotix/neo_simulation2.git
-      version: main
+      version: humble
     status: maintained
   nerian_stereo_ros2:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -677,7 +677,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.8.5-1
+      version: 3.8.6-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6212,7 +6212,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/robot_localization-release.git
-      version: 3.5.1-2
+      version: 3.5.2-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1869,6 +1869,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
+      version: 1.1.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2584,7 +2584,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 0.7.1-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4555,7 +4555,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_worlds-ros2-release.git
-      version: 4.0.2-1
+      version: 4.0.3-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_worlds.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4764,7 +4764,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2770,7 +2770,7 @@ repositories:
     source:
       type: git
       url: https://github.com/iRobotEducation/irobot_create_msgs.git
-      version: main
+      version: humble
   joint_state_publisher:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6401,7 +6401,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_control-release.git
-      version: 2.36.0-1
+      version: 2.36.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7499,7 +7499,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: master
+      version: main
     status: developed
   rviz:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6235,6 +6235,11 @@ repositories:
       type: git
       url: https://github.com/robotont/robotont_driver.git
       version: humble-devel
+    source:
+      type: git
+      url: https://github.com/robotont/robotont_driver.git
+      version: humble-devel
+    status: maintained
   robotraconteur:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8200,7 +8200,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_moveit_config-release.git
-      version: 3.0.2-1
+      version: 3.0.7-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_moveit_config.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8239,7 +8239,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/tiago_robot-release.git
-      version: 4.0.13-1
+      version: 4.0.27-1
     source:
       type: git
       url: https://github.com/pal-robotics/tiago_robot.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4539,7 +4539,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/pal_gazebo_plugins-release.git
-      version: 4.0.4-1
+      version: 4.0.5-1
     source:
       type: git
       url: https://github.com/pal-robotics/pal_gazebo_plugins.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -6290,7 +6290,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
-      version: 0.18.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -2117,7 +2117,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.4.4-1
+      version: 0.4.5-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -964,7 +964,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.2.1-1
+      version: 0.2.2-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -964,7 +964,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/clearpath-gbp/clearpath_common-release.git
-      version: 0.2.2-1
+      version: 0.2.3-1
     source:
       type: git
       url: https://github.com/clearpathrobotics/clearpath_common.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3707,6 +3707,21 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: humble
     status: developed
+  mocap_msgs:
+    doc:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: humble-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs-release.git
+      version: 0.0.4-1
+    source:
+      type: git
+      url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
+      version: master
+    status: developed
   mod:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3818,7 +3818,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.11.4-1
+      version: 2.11.5-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5878,7 +5878,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.1.7-1
+      version: 2.1.8-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -1893,7 +1893,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/Fields2Cover/fields2cover-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -8911,7 +8911,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/Universal_Robots_ROS2_Driver-release.git
-      version: 2.2.9-1
+      version: 2.2.10-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -5793,7 +5793,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.3.2-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7156,11 +7156,21 @@ repositories:
       version: humble
     status: maintained
   rqt_gauges:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_gauges-release.git
+      version: 0.0.1-1
     source:
       test_pull_requests: false
       type: git
       url: https://github.com/ToyotaResearchInstitute/gauges2.git
       version: main
+    status: maintained
   rqt_graph:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4821,7 +4821,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/pal-gbp/play_motion2-release.git
-      version: 0.0.10-1
+      version: 0.0.13-1
     source:
       type: git
       url: https://github.com/pal-robotics/play_motion2.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3290,7 +3290,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: main
+      version: humble
     release:
       packages:
       - bosch_locator_bridge
@@ -3301,7 +3301,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: main
+      version: humble
     status: maintained
   lsc_ros2_driver:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4906,16 +4906,16 @@ repositories:
     doc:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-      version: rolling
+      version: main
     release:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 2.0.0-1
+      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git
-      version: rolling
+      version: main
     status: developed
   pluginlib:
     doc:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3727,6 +3727,21 @@ repositories:
       url: https://github.com/MOCAP4ROS2-Project/mocap_msgs.git
       version: master
     status: developed
+  mocap_optitrack:
+    doc:
+      type: git
+      url: https://github.com/ros-drivers/mocap_optitrack.git
+      version: foxy-devel
+    release:
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/mocap_optitrack-release.git
+      version: 1.0.0-3
+    source:
+      type: git
+      url: https://github.com/ros-drivers/mocap_optitrack.git
+      version: foxy-devel
+    status: maintained
   mod:
     release:
       tags:

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -7469,7 +7469,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.21.1-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -720,10 +720,19 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      - gazebo_model_attachment_plugin_msgs
+      tags:
+        release: release/humble/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.3-2
     source:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: humble
+    status: maintained
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -4855,7 +4855,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.3-1
+      version: 3.8.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/humble/distribution.yaml
+++ b/humble/distribution.yaml
@@ -3206,7 +3206,7 @@ repositories:
       tags:
         release: release/humble/{package}/{version}
       url: https://github.com/ros2-gbp/libcamera-release.git
-      version: 0.1.0-1
+      version: 0.2.0-1
     source:
       type: git
       url: https://git.libcamera.org/libcamera/libcamera.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3023,7 +3023,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4099,7 +4099,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.0-1
+      version: 3.8.3-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5052,7 +5052,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.1.1-1
+      version: 2.1.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6779,7 +6779,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/slider_publisher-release.git
-      version: 2.2.1-3
+      version: 2.3.1-1
     source:
       type: git
       url: https://github.com/oKermorgant/slider_publisher.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4045,7 +4045,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.0.1-2
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6492,7 +6492,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rtabmap-release.git
-      version: 0.21.2-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -7597,7 +7597,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4955,7 +4955,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_building_map_msgs-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_building_map_msgs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1449,7 +1449,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/Fields2Cover/fields2cover-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     status: developed
   filters:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2677,6 +2677,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git
       version: ros_event_camera
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer-release.git
+      version: 1.2.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4129,7 +4129,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-ros-plugins-release.git
-      version: 1.7.3-6
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/PlotJuggler/plotjuggler-ros-plugins.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3899,8 +3899,8 @@ repositories:
   ouster-ros:
     doc:
       type: git
-      url: https://github.com/ouster-lidar/ouster-ros.wiki.git
-      version: master
+      url: https://github.com/ouster-lidar/ouster-ros.git
+      version: iron-devel
     release:
       packages:
       - ouster_msgs
@@ -3912,8 +3912,8 @@ repositories:
     source:
       test_pull_requests: true
       type: git
-      url: https://github.com/ouster-lidar/ouster-ros.wiki.git
-      version: master
+      url: https://github.com/ouster-lidar/ouster-ros.git
+      version: iron-devel
     status: developed
   ouxt_common:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1933,7 +1933,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: devel
+      version: main
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -1942,7 +1942,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: devel
+      version: main
     status: maintained
   grid_map:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1287,7 +1287,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 1.2.2-1
+      version: 1.2.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5051,7 +5051,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3547,7 +3547,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/nlohmann_json_schema_validator_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/nlohmann_json_schema_validator_vendor.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3066,6 +3066,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
     status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1267,12 +1267,13 @@ repositories:
       - etsi_its_denm_msgs
       - etsi_its_messages
       - etsi_its_msgs
+      - etsi_its_msgs_utils
       - etsi_its_primitives_conversion
       - etsi_its_rviz_plugins
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
-      version: 1.0.0-2
+      version: 2.0.0-1
     source:
       type: git
       url: https://github.com/ika-rwth-aachen/etsi_its_messages.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2765,7 +2765,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: main
+      version: humble
     release:
       packages:
       - bosch_locator_bridge
@@ -2776,7 +2776,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: main
+      version: humble
     status: maintained
   log_view:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4386,7 +4386,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/pybind11_json_vendor-release.git
-      version: 0.3.0-1
+      version: 0.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/pybind11_json_vendor.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5011,7 +5011,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.2.4-1
+      version: 2.2.5-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4890,7 +4890,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.3.2-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5059,7 +5059,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.2.2-1
+      version: 2.2.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4940,7 +4940,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_battery-release.git
-      version: 0.2.0-1
+      version: 0.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_battery.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1595,7 +1595,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.3-1
+      version: 0.7.4-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1899,6 +1899,21 @@ repositories:
       url: https://github.com/PickNikRobotics/graph_msgs.git
       version: ros2
     status: maintained
+  grasping_msgs:
+    doc:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros2
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/mikeferguson/grasping_msgs-ros2-gbp.git
+      version: 0.4.0-1
+    source:
+      type: git
+      url: https://github.com/mikeferguson/grasping_msgs.git
+      version: ros2
+    status: maintained
   grbl_msgs:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2998,7 +2998,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
-      version: main
+      version: iron
     release:
       tags:
         release: release/iron/{package}/{version}
@@ -3007,7 +3007,7 @@ repositories:
     source:
       type: git
       url: https://github.com/micro-ROS/micro_ros_msgs.git
-      version: main
+      version: iron
     status: maintained
   microstrain_inertial:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6521,7 +6521,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.21.2-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5715,7 +5715,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_ign-release.git
-      version: 0.247.0-1
+      version: 0.254.0-1
     source:
       test_pull_requests: true
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5430,7 +5430,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.19.2-1
+      version: 3.20.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2009,7 +2009,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
+      version: iron
     release:
       packages:
       - gz_ros2_control
@@ -2017,11 +2017,11 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git
-      version: master
+      version: iron
     status: maintained
   hash_library_vendor:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5123,7 +5123,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_utils-release.git
-      version: 1.5.0-1
+      version: 1.5.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_utils.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3056,35 +3056,6 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
-  mola:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    release:
-      packages:
-      - mola_common
-      - mola_demos
-      - mola_imu_preintegration
-      - mola_input_euroc_dataset
-      - mola_input_kitti_dataset
-      - mola_input_rawlog
-      - mola_input_ros2
-      - mola_kernel
-      - mola_launcher
-      - mola_test_datasets
-      - mola_viz
-      - mola_yaml
-      - mp2p_icp
-      tags:
-        release: release/iron/{package}/{version}
-      url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.2-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    status: developed
   mola_common:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5011,6 +5011,7 @@ repositories:
       version: iron
     release:
       packages:
+      - rmf_charging_schedule
       - rmf_fleet_adapter
       - rmf_fleet_adapter_python
       - rmf_task_ros2
@@ -5019,7 +5020,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.2.3-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6208,6 +6208,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: iron
     status: maintained
+  rqt_gauges:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_gauges-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    status: maintained
   rqt_graph:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5069,7 +5069,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.1.1-1
+      version: 3.1.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1434,6 +1434,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
+      version: 1.2.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6551,7 +6551,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: master
+      version: main
     status: developed
   rviz:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -6468,7 +6468,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -560,7 +560,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.3-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4998,7 +4998,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5343,7 +5343,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/robotraconteur-packaging/robotraconteur-ros2-release.git
-      version: 0.18.0-1
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1867,7 +1867,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - gps_msgs
@@ -1882,7 +1882,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   graph_msgs:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4473,7 +4473,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git
-      version: rolling
+      version: iron
     release:
       packages:
       - r2r_spl_7
@@ -4486,7 +4486,7 @@ repositories:
     source:
       type: git
       url: https://github.com/ros-sports/r2r_spl.git
-      version: rolling
+      version: iron
     status: developed
   radar_msgs:
     release:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3208,7 +3208,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.11.3-1
+      version: 2.11.4-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3081,6 +3081,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
+    release:
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_common-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3177,6 +3177,16 @@ repositories:
       url: https://github.com/ros-planning/moveit_visual_tools.git
       version: ros2
     status: maintained
+  mp2p_icp:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mp2p_icp.git
+      version: master
+    status: developed
   mqtt_client:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5465,7 +5465,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 3.20.0-1
+      version: 3.20.1-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -543,7 +543,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.5-1
+      version: 3.8.6-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1610,7 +1610,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ros_foxglove_msgs-release.git
-      version: 2.1.1-4
+      version: 2.3.0-1
     source:
       type: git
       url: https://github.com/foxglove/schemas.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3085,6 +3085,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2924,7 +2924,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/menge_vendor-release.git
-      version: 1.1.0-1
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/open-rmf/menge_vendor.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -4150,7 +4150,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.3-1
+      version: 3.8.6-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3204,7 +3204,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.11.4-1
+      version: 2.11.5-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -3641,7 +3641,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - novatel_gps_driver
@@ -3653,7 +3653,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   ntpd_driver:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -159,7 +159,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake_catch2-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/ament_cmake_catch2.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -1650,7 +1650,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: iron
     release:
       packages:
       - gazebo_ros2_control
@@ -1658,11 +1658,11 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.2-1
+      version: 0.6.3-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git
-      version: master
+      version: iron
     status: developed
   gazebo_ros_pkgs:
     doc:

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -560,7 +560,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.2-1
+      version: 4.4.3-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -2236,6 +2236,25 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: rolling
     status: maintained
+  imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/iron/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_pipeline-release.git
+      version: 0.4.1-1
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    status: maintained
   imu_tools:
     doc:
       type: git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5088,7 +5088,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.1.0-1
+      version: 3.1.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5108,7 +5108,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.7.1-1
+      version: 1.7.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git

--- a/iron/distribution.yaml
+++ b/iron/distribution.yaml
@@ -5179,7 +5179,7 @@ repositories:
       tags:
         release: release/iron/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_visualization_msgs-release.git
-      version: 1.3.0-1
+      version: 1.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_visualization_msgs.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10710,11 +10710,6 @@ repositories:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git
       version: master
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/tork-a/rtsprofile-release.git
-      version: 2.0.0-3
     source:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1957,7 +1957,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_polaris_ros-release.git
-      version: 1.1.2-1
+      version: 1.1.3-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_polaris_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -9167,7 +9167,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/robotraconteur-packaging/robotraconteur-ros-release.git
-      version: 0.18.0-2
+      version: 1.0.0-1
     source:
       type: git
       url: https://github.com/robotraconteur/robotraconteur.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -538,10 +538,18 @@ repositories:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+    release:
+      packages:
+      - gazebo_model_attachment_plugin
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/boeing_gazebo_model_attachement_plugin-release.git
+      version: 1.0.2-5
     source:
       type: git
       url: https://github.com/Boeing/gazebo_model_attachment_plugin.git
       version: noetic
+    status: maintained
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4682,10 +4682,11 @@ repositories:
       - jsk_recognition_msgs
       - jsk_recognition_utils
       - resized_image_transport
+      - sound_classification
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git
-      version: 1.2.17-1
+      version: 1.2.17-2
     source:
       type: git
       url: https://github.com/jsk-ros-pkg/jsk_recognition.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10700,11 +10700,6 @@ repositories:
       type: git
       url: https://github.com/tork-a/rtctree-release.git
       version: release/hydro/rtctree
-    release:
-      tags:
-        release: release/noetic/{package}/{version}
-      url: https://github.com/tork-a/rtctree-release.git
-      version: 3.0.1-3
     source:
       type: git
       url: https://github.com/gbiggs/rtctree.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -4652,7 +4652,6 @@ repositories:
       - jsk_recognition_msgs
       - jsk_recognition_utils
       - resized_image_transport
-      - sound_classification
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/tork-a/jsk_recognition-release.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10708,7 +10708,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.21.3-1
+      version: 0.21.3-4
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -501,6 +501,21 @@ repositories:
       url: https://github.com/uos/basler_tof.git
       version: noetic
     status: developed
+  bcr_bot:
+    doc:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros1
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/blackcoffeerobotics/bcr_bot-release.git
+      version: 0.0.1-4
+    source:
+      type: git
+      url: https://github.com/blackcoffeerobotics/bcr_bot.git
+      version: ros1
+    status: developed
   behaviortree_cpp_v3:
     doc:
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10745,6 +10745,11 @@ repositories:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git
       version: master
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/rtsprofile-release.git
+      version: 2.0.0-4
     source:
       type: git
       url: https://github.com/gbiggs/rtsprofile.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -2613,6 +2613,31 @@ repositories:
       url: https://github.com/shadow-robot/ethercat_grant.git
       version: noetic-devel
     status: maintained
+  etsi_its_messages:
+    release:
+      packages:
+      - etsi_its_cam_coding
+      - etsi_its_cam_conversion
+      - etsi_its_cam_msgs
+      - etsi_its_coding
+      - etsi_its_conversion
+      - etsi_its_denm_coding
+      - etsi_its_denm_conversion
+      - etsi_its_denm_msgs
+      - etsi_its_messages
+      - etsi_its_msgs
+      - etsi_its_msgs_utils
+      - etsi_its_primitives_conversion
+      - etsi_its_rviz_plugins
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages-release.git
+      version: 2.0.0-1
+    source:
+      type: git
+      url: https://github.com/ika-rwth-aachen/etsi_its_messages.git
+      version: main
+    status: developed
   euslime:
     release:
       tags:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -5714,7 +5714,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/LORD-MicroStrain/microstrain_inertial-release.git
-      version: 3.1.0-1
+      version: 3.2.0-3
     source:
       test_pull_requests: true
       type: git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -573,11 +573,11 @@ repositories:
   boeing_gazebo_set_joint_positions_plugin:
     doc:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: noetic
     source:
       type: git
-      url: https://github.com/Boeing/gazebo_set_joint_positions_plugin.git
+      url: https://github.com/Boeing/boeing_gazebo_set_joint_positions_plugin.git
       version: noetic
   bond_core:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -527,7 +527,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.2-1
+      version: 4.4.3-2
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7595,7 +7595,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.3-1
+      version: 3.8.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12176,7 +12176,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver-release.git
-      version: 2.1.2-1
+      version: 2.1.3-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS_Driver.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -12111,13 +12111,14 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git
-      version: melodic
+      version: noetic
     release:
       packages:
       - universal_robots
       - ur10_moveit_config
       - ur10e_moveit_config
       - ur16e_moveit_config
+      - ur20_moveit_config
       - ur3_moveit_config
       - ur3e_moveit_config
       - ur5_moveit_config
@@ -12127,11 +12128,11 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/ros-industrial-release/universal_robot-release.git
-      version: 1.3.1-1
+      version: 1.3.2-1
     source:
       type: git
       url: https://github.com/ros-industrial/universal_robot.git
-      version: melodic-devel
+      version: noetic-devel
     status: developed
   ur_client_library:
     doc:

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7610,7 +7610,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.4-1
+      version: 3.8.5-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10729,6 +10729,11 @@ repositories:
       type: git
       url: https://github.com/tork-a/rtctree-release.git
       version: release/hydro/rtctree
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/tork-a/rtctree-release.git
+      version: 3.0.1-4
     source:
       type: git
       url: https://github.com/gbiggs/rtctree.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -80,6 +80,11 @@ repositories:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros.git
       version: noetic
+    release:
+      tags:
+        release: release/noetic/{package}/{version}
+      url: https://github.com/ros2-gbp/adi_tmcl-release.git
+      version: 4.0.0-1
     source:
       type: git
       url: https://github.com/analogdevicesinc/tmcl_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1915,7 +1915,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_fca_ros-release.git
-      version: 1.3.2-1
+      version: 1.3.3-1
     source:
       type: git
       url: https://bitbucket.org/DataspeedInc/dbw_fca_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -7640,7 +7640,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/facontidavide/plotjuggler-release.git
-      version: 3.8.5-1
+      version: 3.8.6-2
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10671,7 +10671,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap-release.git
-      version: 0.21.1-1
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -10702,7 +10702,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/introlab/rtabmap_ros-release.git
-      version: 0.21.1-4
+      version: 0.21.3-1
     source:
       type: git
       url: https://github.com/introlab/rtabmap_ros.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -510,7 +510,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/BehaviorTree/behaviortree_cpp_v3-release.git
-      version: 3.8.5-1
+      version: 3.8.6-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -469,7 +469,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/squarerobot/bagger-release.git
-      version: 0.1.4-1
+      version: 0.1.5-2
     source:
       type: git
       url: https://github.com/squarerobot/bagger.git

--- a/noetic/distribution.yaml
+++ b/noetic/distribution.yaml
@@ -1936,7 +1936,7 @@ repositories:
       tags:
         release: release/noetic/{package}/{version}
       url: https://github.com/DataspeedInc-release/dbw_mkz_ros-release.git
-      version: 1.6.4-1
+      version: 1.6.5-1
     source:
       type: git
       url: https://bitbucket.org/dataspeedinc/dbw_mkz_ros.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -584,7 +584,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.3-1
+      version: 4.5.0-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -567,7 +567,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp-release.git
-      version: 3.8.4-1
+      version: 3.8.6-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -259,7 +259,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_lint-release.git
-      version: 0.16.1-1
+      version: 0.16.2-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -725,7 +725,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/class_loader-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3780,7 +3780,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pick_ik-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/pick_ik.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2365,7 +2365,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/laser_geometry-release.git
-      version: 2.6.0-1
+      version: 2.7.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2902,6 +2902,16 @@ repositories:
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
     status: developed
+  motion_capture_tracking:
+    doc:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    source:
+      type: git
+      url: https://github.com/IMRCLab/motion_capture_tracking.git
+      version: ros2
+    status: developed
   moveit:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2916,6 +2916,11 @@ repositories:
       type: git
       url: https://github.com/MOLAorg/mola_common.git
       version: develop
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/mola_common-release.git
+      version: 0.3.0-1
     source:
       type: git
       url: https://github.com/MOLAorg/mola_common.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5727,7 +5727,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_typesupport_fastrtps-release.git
-      version: 3.3.0-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1375,7 +1375,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/fastrtps-release.git
-      version: 2.12.1-1
+      version: 2.11.2-1
     source:
       test_commits: true
       test_pull_requests: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2955,7 +2955,6 @@ repositories:
       packages:
       - chomp_motion_planner
       - moveit
-      - moveit_chomp_optimizer_adapter
       - moveit_common
       - moveit_configs_utils
       - moveit_core
@@ -2996,7 +2995,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/moveit2-release.git
-      version: 2.8.0-2
+      version: 2.9.0-1
     source:
       test_commits: false
       test_pull_requests: false

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5672,7 +5672,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl_python-release.git
-      version: 0.20.0-1
+      version: 0.21.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6238,7 +6238,7 @@ repositories:
     source:
       type: git
       url: https://github.com/pantor/ruckig.git
-      version: master
+      version: main
     status: developed
   rviz:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4754,7 +4754,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.3.3-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5444,7 +5444,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros_tutorials-release.git
-      version: 1.7.4-1
+      version: 1.8.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1589,7 +1589,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/gazebo_ros2_control-release.git
-      version: 0.6.2-1
+      version: 0.7.0-1
     source:
       type: git
       url: https://github.com/ros-simulation/gazebo_ros2_control.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2606,7 +2606,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: main
+      version: humble
     release:
       packages:
       - bosch_locator_bridge
@@ -2617,7 +2617,7 @@ repositories:
     source:
       type: git
       url: https://github.com/boschglobal/locator_ros_bridge.git
-      version: main
+      version: humble
     status: maintained
   log_view:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2404,7 +2404,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4755,7 +4755,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_simulation-release.git
-      version: 2.2.1-1
+      version: 2.2.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_simulation.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7292,7 +7292,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom-release.git
-      version: 3.1.1-1
+      version: 4.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4518,7 +4518,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcutils-release.git
-      version: 6.4.1-1
+      version: 6.5.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3050,7 +3050,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/mrpt2-release.git
-      version: 2.11.4-1
+      version: 2.11.5-1
     source:
       type: git
       url: https://github.com/MRPT/mrpt.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4581,7 +4581,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/resource_retriever-release.git
-      version: 3.3.1-1
+      version: 3.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4382,7 +4382,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl_logging-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5294,7 +5294,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2cli-release.git
-      version: 0.30.0-1
+      version: 0.30.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4159,7 +4159,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/qt_gui_core-release.git
-      version: 2.7.0-1
+      version: 2.7.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4451,7 +4451,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclpy-release.git
-      version: 6.0.0-1
+      version: 7.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2100,6 +2100,11 @@ repositories:
       url: https://github.com/ros-perception/image_transport_plugins.git
       version: rolling
     status: maintained
+  imu_pipeline:
+    source:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
   imu_tools:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4988,7 +4988,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_implementation-release.git
-      version: 2.14.0-1
+      version: 2.15.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4772,7 +4772,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.3.0-1
+      version: 3.3.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4724,6 +4724,7 @@ repositories:
       version: main
     release:
       packages:
+      - rmf_charging_schedule
       - rmf_fleet_adapter
       - rmf_fleet_adapter_python
       - rmf_task_ros2
@@ -4732,7 +4733,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.3.2-1
+      version: 2.4.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2579,7 +2579,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/libstatistics_collector-release.git
-      version: 1.6.4-1
+      version: 1.7.0-1
     source:
       type: git
       url: https://github.com/ros-tooling/libstatistics_collector.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5923,6 +5923,21 @@ repositories:
       url: https://github.com/ros-visualization/rqt_console.git
       version: rolling
     status: maintained
+  rqt_gauges:
+    doc:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/rqt_gauges-release.git
+      version: 0.0.1-1
+    source:
+      type: git
+      url: https://github.com/ToyotaResearchInstitute/gauges2.git
+      version: main
+    status: maintained
   rqt_graph:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -801,7 +801,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/common_interfaces-release.git
-      version: 5.2.1-1
+      version: 5.2.2-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4711,7 +4711,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_internal_msgs-release.git
-      version: 3.2.0-1
+      version: 3.2.1-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_internal_msgs.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1882,7 +1882,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ign_ros2_control-release.git
-      version: 1.1.2-1
+      version: 1.2.0-1
     source:
       type: git
       url: https://github.com/ros-controls/gz_ros2_control.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4335,7 +4335,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcl-release.git
-      version: 8.0.0-1
+      version: 9.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3844,7 +3844,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/plotjuggler-release.git
-      version: 3.8.3-1
+      version: 3.8.4-1
     source:
       type: git
       url: https://github.com/facontidavide/PlotJuggler.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -941,7 +941,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/demos-release.git
-      version: 0.32.0-1
+      version: 0.32.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1413,7 +1413,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/Fields2Cover/Fields2Cover-release.git
-      version: 1.2.1-1
+      version: 1.2.1-2
     status: developed
   filters:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4954,7 +4954,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw_fastrtps-release.git
-      version: 8.0.0-1
+      version: 8.1.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2859,7 +2859,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/microstrain_inertial-release.git
-      version: 3.1.0-1
+      version: 3.2.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4125,7 +4125,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/python_qt_binding-release.git
-      version: 1.3.0-1
+      version: 2.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4714,7 +4714,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_ros2-release.git
-      version: 2.4.0-1
+      version: 2.5.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_ros2.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4772,7 +4772,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_task-release.git
-      version: 2.3.2-1
+      version: 2.3.3-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_task.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1526,7 +1526,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/foxglove_bridge-release.git
-      version: 0.7.4-1
+      version: 0.7.5-1
     source:
       type: git
       url: https://github.com/foxglove/ros-foxglove-bridge.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4467,7 +4467,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rcpputils-release.git
-      version: 2.8.1-1
+      version: 2.9.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2542,6 +2542,11 @@ repositories:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git
       version: ros_event_camera
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/libcaer-release.git
+      version: 1.0.1-1
     source:
       type: git
       url: https://github.com/ros-event-camera/libcaer.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -143,7 +143,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ament_cmake-release.git
-      version: 2.3.1-1
+      version: 2.3.2-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4791,7 +4791,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic-release.git
-      version: 3.2.0-1
+      version: 3.3.0-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2775,7 +2775,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_message_filters-release.git
-      version: 4.10.1-1
+      version: 4.11.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1398,6 +1398,11 @@ repositories:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git
       version: master
+    release:
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/ffmpeg_image_transport_msgs-release.git
+      version: 1.0.2-1
     source:
       type: git
       url: https://github.com/ros-misc-utilities/ffmpeg_image_transport_msgs.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4435,7 +4435,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rclcpp-release.git
-      version: 24.0.0-1
+      version: 25.0.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1718,7 +1718,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/geometry2-release.git
-      version: 0.34.0-1
+      version: 0.35.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5191,7 +5191,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ros2_controllers-release.git
-      version: 4.2.0-1
+      version: 4.3.0-1
     source:
       type: git
       url: https://github.com/ros-controls/ros2_controllers.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7226,7 +7226,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdf-release.git
-      version: 2.9.0-1
+      version: 2.10.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3332,7 +3332,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - novatel_gps_driver
@@ -3344,7 +3344,7 @@ repositories:
     source:
       type: git
       url: https://github.com/swri-robotics/novatel_gps_driver.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   ntpd_driver:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6194,7 +6194,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/RSL-release.git
-      version: 1.0.1-1
+      version: 1.1.0-1
     source:
       type: git
       url: https://github.com/PickNikRobotics/RSL.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5809,7 +5809,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rqt-release.git
-      version: 1.4.1-1
+      version: 1.5.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2921,6 +2921,16 @@ repositories:
       url: https://github.com/MOLAorg/mola.git
       version: develop
     status: developed
+  mola_common:
+    doc:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    source:
+      type: git
+      url: https://github.com/MOLAorg/mola_common.git
+      version: develop
+    status: developed
   moveit:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1829,7 +1829,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: devel
+      version: main
     release:
       tags:
         release: release/rolling/{package}/{version}
@@ -1838,7 +1838,7 @@ repositories:
     source:
       type: git
       url: https://github.com/flynneva/grbl_ros.git
-      version: devel
+      version: main
     status: maintained
   gscam:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7308,7 +7308,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/urdfdom_headers-release.git
-      version: 1.1.0-2
+      version: 1.1.1-1
     source:
       type: git
       url: https://github.com/ros/urdfdom_headers.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3860,7 +3860,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/pluginlib-release.git
-      version: 5.3.1-1
+      version: 5.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2101,10 +2101,24 @@ repositories:
       version: rolling
     status: maintained
   imu_pipeline:
+    doc:
+      type: git
+      url: https://github.com/ros-perception/imu_pipeline.git
+      version: ros2
+    release:
+      packages:
+      - imu_pipeline
+      - imu_processors
+      - imu_transformer
+      tags:
+        release: release/rolling/{package}/{version}
+      url: https://github.com/ros2-gbp/imu_pipeline-release.git
+      version: 0.4.1-1
     source:
       type: git
       url: https://github.com/ros-perception/imu_pipeline.git
       version: ros2
+    status: maintained
   imu_tools:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -584,7 +584,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/behaviortree_cpp_v4-release.git
-      version: 4.4.2-1
+      version: 4.4.3-1
     source:
       type: git
       url: https://github.com/BehaviorTree/BehaviorTree.CPP.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1778,7 +1778,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: ros2-devel
     release:
       packages:
       - gps_msgs
@@ -1793,7 +1793,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/swri-robotics/gps_umd.git
-      version: dashing-devel
+      version: ros2-devel
     status: developed
   graph_msgs:
     doc:

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2229,7 +2229,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/kdl_parser-release.git
-      version: 2.10.0-1
+      version: 2.11.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -5566,7 +5566,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rosidl-release.git
-      version: 4.4.2-1
+      version: 4.5.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4593,7 +4593,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rig_reconfigure-release.git
-      version: 1.3.2-1
+      version: 1.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2892,35 +2892,6 @@ repositories:
       url: https://github.com/DFKI-NI/mir_robot.git
       version: rolling
     status: developed
-  mola:
-    doc:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    release:
-      packages:
-      - mola_common
-      - mola_demos
-      - mola_imu_preintegration
-      - mola_input_euroc_dataset
-      - mola_input_kitti_dataset
-      - mola_input_rawlog
-      - mola_input_ros2
-      - mola_kernel
-      - mola_launcher
-      - mola_test_datasets
-      - mola_viz
-      - mola_yaml
-      - mp2p_icp
-      tags:
-        release: release/rolling/{package}/{version}
-      url: https://github.com/ros2-gbp/mola-release.git
-      version: 0.2.2-1
-    source:
-      type: git
-      url: https://github.com/MOLAorg/mola.git
-      version: develop
-    status: developed
   mola_common:
     doc:
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4881,7 +4881,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmw-release.git
-      version: 7.2.2-1
+      version: 7.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7664,7 +7664,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/yaml_cpp_vendor-release.git
-      version: 8.3.0-1
+      version: 8.3.1-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -7171,7 +7171,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/ur_description-release.git
-      version: 2.2.2-1
+      version: 2.2.4-1
     source:
       type: git
       url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2145,7 +2145,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/interactive_markers-release.git
-      version: 2.5.2-1
+      version: 2.5.3-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -3200,7 +3200,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/navigation_msgs-release.git
-      version: 2.3.0-1
+      version: 2.4.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -2439,7 +2439,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/launch_ros-release.git
-      version: 0.26.2-1
+      version: 0.26.3-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -6248,7 +6248,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rviz-release.git
-      version: 13.2.0-1
+      version: 13.3.0-1
     source:
       test_pull_requests: true
       type: git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -4811,7 +4811,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/rmf_traffic_editor-release.git
-      version: 1.8.1-1
+      version: 1.8.2-1
     source:
       type: git
       url: https://github.com/open-rmf/rmf_traffic_editor.git

--- a/rolling/distribution.yaml
+++ b/rolling/distribution.yaml
@@ -1247,7 +1247,7 @@ repositories:
       tags:
         release: release/rolling/{package}/{version}
       url: https://github.com/ros2-gbp/event_camera_codecs-release.git
-      version: 1.0.2-1
+      version: 1.0.3-1
     source:
       type: git
       url: https://github.com/ros-event-camera/event_camera_codecs.git

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1200,6 +1200,12 @@ fxload:
   debian: [fxload]
   fedora: [fxload]
   ubuntu: [fxload]
+g++-10:
+  debian:
+    bullseye: [g++-10]
+  ubuntu:
+    focal: [g++-10]
+    jammy: [g++-10]
 g++-5-arm-linux-gnueabihf:
   ubuntu: [g++-5-arm-linux-gnueabihf]
 g++-5-multilib:

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -768,6 +768,9 @@ daemontools:
   nixos: [daemontools]
   openembedded: [daemontools@meta-oe]
   ubuntu: [daemontools]
+darknet:
+  debian: [darknet]
+  ubuntu: [darknet]
 dcraw:
   arch: [dcraw]
   debian: [dcraw]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7001,6 +7001,23 @@ pandoc:
   nixos: [pandoc]
   rhel: [pandoc]
   ubuntu: [pandoc]
+patchelf:
+  alpine: [patchelf]
+  arch: [patchelf]
+  debian: [patchelf]
+  fedora: [patchelf]
+  freebsd: [sysutils/patchelf]
+  gentoo: [dev-util/patchelf]
+  macports: [patchelf]
+  nixos: [patchelf]
+  openembedded: [patchelf@openembedded-core]
+  opensuse: [patchelf]
+  osx:
+    homebrew:
+      packages: [patchelf]
+  rhel: [patchelf]
+  slackware: [patchelf]
+  ubuntu: [patchelf]
 pcre:
   alpine: [pcre-dev]
   arch: [pcre]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -949,6 +949,16 @@ espeak:
   gentoo: [app-accessibility/espeak]
   nixos: [espeak]
   ubuntu: [espeak]
+ethtool:
+  alpine: [ethtool]
+  arch: [ethtool]
+  debian: [ethtool]
+  fedora: [ethtool]
+  gentoo: [ethtool]
+  nixos: [ethtool]
+  opensuse: [ethtool]
+  rhel: [ethtool]
+  ubuntu: [ethtool]
 exfat-fuse:
   debian: [exfat-fuse]
   gentoo: [sys-fs/fuse-exfat]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7430,6 +7430,13 @@ qttools5-dev-tools:
   openembedded: [qttools@meta-qt5]
   rhel: [qt5-qttools-devel]
   ubuntu: [qttools5-dev-tools]
+qtwebengine5-dev:
+  debian: [qtwebengine5-dev]
+  fedora: [qt5-qtwebengine-devel]
+  gentoo: [dev-qt/qtwebengine]
+  nixos: [libsForQt5.qt5.qtwebengine]
+  rhel: [qt5-qtwebengine-devel]
+  ubuntu: [qtwebengine5-dev]
 r-base:
   debian: [r-base]
   fedora: [R]

--- a/rosdep/osx-homebrew.yaml
+++ b/rosdep/osx-homebrew.yaml
@@ -659,6 +659,10 @@ python-cairo:
   osx:
     homebrew:
       packages: [py2cairo]
+python-omniorb:
+  osx:
+    homebrew:
+      packages: [omniorb]
 python-opencv:
   osx:
     homebrew:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2912,9 +2912,6 @@ python-psycopg2:
   debian: [python-psycopg2]
   fedora: [python-psycopg2]
   gentoo: [=dev-python/psycopg-2*]
-  ubuntu:
-    '*': [python-psycopg2]
-    focal: [python3-psycopg2]
 python-pulsectl-pip:
   debian:
     pip:
@@ -7615,6 +7612,12 @@ python3-psutil:
   rhel: ['python%{python3_pkgversion}-psutil']
   slackware: [psutil]
   ubuntu: [python3-psutil]
+python3-psycopg2:
+  debian: [python3-psycopg2]
+  fedora: [python3-psycopg2]
+  opensuse: [python3-psycopg2]
+  rhel: [python3-psycopg2]
+  ubuntu: [python3-psycopg2]
 python3-py3exiv2-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2561,6 +2561,11 @@ python-objectpath-pip:
   ubuntu:
     pip:
       packages: [objectpath]
+python-omniorb:
+  fedora: [python-omniORB, omniORB-devel]
+  gentoo: ['net-misc/omniORB[python]']
+  ubuntu:
+    focal: [python-omniorb, python-omniorb-omg, omniidl-python]
 python-open3d-pip:
   debian:
     pip:

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5398,6 +5398,13 @@ python3-cryptography:
   opensuse: [python3-cryptography]
   rhel: ['python%{python3_pkgversion}-cryptography']
   ubuntu: [python3-cryptography]
+python3-cvxopt:
+  arch: [python-cvxopt]
+  debian: [python3-cvxopt]
+  fedora: [python-cvxopt]
+  gentoo: [dev-python/cvxopt]
+  nixos: [python311Packages.cvxopt]
+  ubuntu: [python3-cvxopt]
 python3-cvxpy-pip: *migrate_eol_2025_04_30_python3_cvxpy_pip
 python3-cycler:
   arch: [python-cycler]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -5109,6 +5109,19 @@ python3-bson:
       packages: [bson]
   rhel: ['python%{python3_pkgversion}-bson']
   ubuntu: [python3-bson]
+python3-build:
+  alpine: [py3-build]
+  arch: [python-build]
+  debian: [python3-build]
+  fedora: [python3-build]
+  gentoo: [dev-python/build]
+  osx: [python-build]
+  rhel:
+    '*': [python3-build]
+    '8': null
+  ubuntu:
+    '*': [python3-build]
+    focal: null
 python3-cairo:
   arch: [python-cairo]
   debian: [python3-cairo]

--- a/scripts/check_duplicates.py
+++ b/scripts/check_duplicates.py
@@ -42,11 +42,14 @@ def create_default_sources():
     sources = []
     # get all rosdistro files
     basedir = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(__file__)), '..'))
-    filepath = os.path.join(basedir, 'index.yaml')
+    filepath = os.path.join(basedir, 'index-v4.yaml')
     with open(filepath) as f:
         content = f.read()
     index = yaml.safe_load(content)
-    for distro in index['distributions']:
+    for distro, metadata in index['distributions'].items():
+        if metadata['distribution_status'] == 'end-of-life':
+            # Skip end-of-life distributions
+            continue
         distfile = 'file://' + basedir + '/' + distro + '/distribution.yaml'
         print('loading %s' % distfile)
         try:


### PR DESCRIPTION
Conflict in `rosdep/python.yaml` is manually resolved.

```
diff --cc rosdep/python.yaml
index 5f530aa9b,8116e2602..000000000
--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@@ -5282,8 -5106,20 +5278,21 @@@ python3-bson
        packages: [bson]
    rhel: ['python%{python3_pkgversion}-bson']
    ubuntu: [python3-bson]
+ python3-build:
+   alpine: [py3-build]
+   arch: [python-build]
+   debian: [python3-build]
+   fedora: [python3-build]
+   gentoo: [dev-python/build]
+   osx: [python-build]
+   rhel:
+     '*': [python3-build]
+     '8': null
+   ubuntu:
+     '*': [python3-build]
+     focal: null
  python3-cairo:
 +  alpine: [py3-cairo]
    arch: [python-cairo]
    debian: [python3-cairo]
    fedora: [python3-cairo]
@@@ -7805,10 -7612,12 +7829,19 @@@ python3-psutil
    rhel: ['python%{python3_pkgversion}-psutil']
    slackware: [psutil]
    ubuntu: [python3-psutil]
++<<<<<<< HEAD
 +python3-pulsectl:
 +  alpine:
 +    '*': [py3-pulsectl]
 +    '3.8': null
++=======
+ python3-psycopg2:
+   debian: [python3-psycopg2]
+   fedora: [python3-psycopg2]
+   opensuse: [python3-psycopg2]
+   rhel: [python3-psycopg2]
+   ubuntu: [python3-psycopg2]
++>>>>>>> upstream/master
  python3-py3exiv2-pip:
    debian:
      pip:
@@@ -7999,8 -7804,20 +8032,21 @@@ python3-pygraphviz
    rhel: ['python%{python3_pkgversion}-pygraphviz']
    slackware: [pygraphviz]
    ubuntu: [python3-pygraphviz]
+ python3-pyinotify:
+   alpine: [py3-inotify]
+   arch: [python-pyinotify]
+   debian: [python3-pyinotify]
+   fedora: [python3-inotify]
+   gentoo: [dev-python/pyinotify]
+   nixos: [python3Packages.pyinotify]
+   opensuse: [python3-pyinotify]
+   osx:
+     pip:
+       packages: [pyinotify]
+   rhel: [python3-inotify]
+   ubuntu: [python3-pyinotify]
  python3-pykdl:
 +  alpine: [py3-kdl]
    debian:
      '*': [python3-pykdl]
      stretch: null
```