### PR TITLE
Add zeromq and ncurses entries for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6429,6 +6429,7 @@ libzip-dev:
   gentoo: [dev-libs/libzip]
   ubuntu: [libzip-dev]
 libzmq3-dev:
+  alpine: [zeromq-dev]
   arch: [zeromq]
   debian: [libzmq3-dev]
   fedora: [cppzmq-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -4336,6 +4336,7 @@ libnanopb-dev:
     '*': [libnanopb-dev]
     bionic: null
 libncurses:
+  alpine: [ncurses]
   arch: [ncurses]
   debian: [libncurses5]
   fedora: [ncurses]
@@ -4346,6 +4347,7 @@ libncurses:
   rhel: [ncurses]
   ubuntu: [libncurses5]
 libncurses-dev:
+  alpine: [ncurses-dev]
   arch: [ncurses]
   debian: [libncurses5-dev]
   fedora: [ncurses-devel]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -6558,7 +6558,9 @@ python3-gst-1.0:
   alpine: [py3-gst]
   debian: [python3-gst-1.0]
   fedora: [python3-gstreamer1]
-  ubuntu: [python3-gst-1.0]
+  ubuntu:
+    '*': [python3-gst-1.0]
+    noble: null
 python3-gurobipy-pip: *migrate_eol_2025_04_30_python3_gurobipy_pip
 python3-gymnasium-pip:
   debian:


### PR DESCRIPTION
Unrelated to the original goal of this PR, `python3-gst-1.0` is ignored for `ubuntu:noble` as it is not available for `amd64` https://packages.ubuntu.com/noble/python3-gst-1.0