### PR TITLE
Add glu-dev to opengl for alpine entry

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7038,7 +7038,7 @@ opende:
   nixos: [ode]
   ubuntu: [libode-dev]
 opengl:
-  alpine: [mesa-dev glu-dev]
+  alpine: [mesa-dev, glu-dev]
   arch: [mesa]
   debian: [libgl1-mesa-dev, libglu1-mesa-dev]
   fedora: [mesa-libGL-devel, mesa-libGLU-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7038,7 +7038,7 @@ opende:
   nixos: [ode]
   ubuntu: [libode-dev]
 opengl:
-  alpine: [mesa-dev]
+  alpine: [mesa-dev glu-dev]
   arch: [mesa]
   debian: [libgl1-mesa-dev, libglu1-mesa-dev]
   fedora: [mesa-libGL-devel, mesa-libGLU-devel]


### PR DESCRIPTION
The purpose of this PR is successfully build `rviz_ogre_vendor` in https://github.com/seqsense/aports-ros-experimental/pull/893.

`GL/glu.h` is required when building `ogre` via [`rviz_ogre_vendor`](https://github.com/ros2/rviz/tree/humble/rviz_ogre_vendor) package.

The header file belongs to [`glu-dev`](https://pkgs.alpinelinux.org/contents?file=&path=&name=glu-dev&branch=v3.17&repo=main&arch=x86_64) package for alpine.

`rviz_ogre_vendor` has [a dependency on `opengl`](https://github.com/ros2/rviz/blob/c6c705ef88bcc38adc1498ff19583f7e119ffcc4/rviz_ogre_vendor/package.xml#L32), and it's [`libgl1-mesa-dev` and `libglu1-mesa-dev` for ubuntu](https://github.com/ros/rosdistro/blob/80b20be3f221f460bfd96ff4c5cb4402b8a36b03/rosdep/base.yaml#L6930). 

`GL/glu.h` is contained in [`libglu1-mesa-dev` for ubuntu jammy](https://packages.ubuntu.com/jammy/amd64/libglu1-mesa-dev/filelist). So I think adding `glu-dev` to `opengl` for alpine is reasonable.