### PR TITLE
Add xtensor for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8721,6 +8721,11 @@ xsltproc:
   nixos: [libxslt]
   ubuntu: [xsltproc]
 xtensor:
+  alpine:
+    '*': [xtensor]
+    '3.11': null
+    '3.14': null
+    '3.8': null
   arch: [xtensor]
   fedora: [xtensor-devel]
   nixos: [xtensor]


### PR DESCRIPTION
`xtensor` will be added by https://github.com/seqsense/aports-ros-experimental/pull/901