### PR TITLE
Fix libceres-dev entry for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3065,7 +3065,7 @@ libcereal-dev:
   ubuntu: [libcereal-dev]
 libceres-dev:
   alpine:
-    '*': [ceres-solver]
+    '*': [ceres-solver, ceres-solver-dev]
     '3.11': null
     '3.14': null
     '3.8': null


### PR DESCRIPTION
`ceres-solver` for alpine doesn't contain header files but [`libceres-dev` for `Ubuntu jammy`](https://packages.ubuntu.com/jammy/libceres-dev) does, so `ceres-solver-dev` should also be installed.