### PR TITLE
Add socat for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -7935,6 +7935,7 @@ snappy:
   rhel: [snappy-devel]
   ubuntu: [libsnappy-dev]
 socat:
+  alpine: [socat]
   arch: [socat]
   debian: [socat]
   fedora: [socat]


### PR DESCRIPTION
- [3.17](https://pkgs.alpinelinux.org/package/v3.17/main/x86_64/socat)
- [3.14](https://pkgs.alpinelinux.org/package/v3.14/main/x86_64/socat)
- [3.11](https://pkgs.alpinelinux.org/package/v3.11/main/x86_64/socat)