### PR TITLE
Update alpine version for rosdep_repo_check

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -6812,7 +6812,7 @@ libvpx-dev:
   ubuntu: [libvpx-dev]
 libvtk:
   alpine:
-    '*': [vtk8-dev]
+    '*': [vtk-dev]
     '3.11': [vtk7-dev]
     '3.8': [vtk7-dev]
   arch: [vtk]
@@ -6845,7 +6845,7 @@ libvtk-java:
     bionic: [libvtk6-java]
 libvtk-qt:
   alpine:
-    '*': [vtk8-dev]
+    '*': [vtk-dev]
     '3.11': [vtk7-dev]
     '3.8': [vtk7-dev]
   arch: [vtk]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -10079,7 +10079,11 @@ python3-singleton-pattern-decorator-pip:
     pip:
       packages: [singleton-pattern-decorator]
 python3-sip:
-  alpine: [py3-sip]
+  alpine:
+    '*': [py3-sip4, py3-sip4-dev]
+    '3.11': [py-sip, py-sip-dev]
+    '3.14': [py-sip, py-sip-dev]
+    '3.8': [py-sip, py-sip-dev]
   debian: [python3-sip-dev]
   fedora: [python3-sip-devel]
   gentoo: [dev-python/sip]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -4001,7 +4001,9 @@ python-singledispatch:
   gentoo: [virtual/python-singledispatch]
   ubuntu: [python-singledispatch]
 python-sip:
-  alpine: [py-sip-dev, py-sip]
+  alpine:
+    '*': null
+    '3.8': [py-sip-dev, py-sip]
   arch: [sip, python2-sip]
   debian: [python-sip-dev]
   freebsd: [py27-sip]
@@ -4018,7 +4020,9 @@ python-sip:
   ubuntu:
     '*': [python-sip-dev]
 python-sip4:
-  alpine: [py-sip-dev, py-sip]
+  alpine:
+    '*': null
+    '3.8': [py-sip-dev, py-sip]
   debian: [python-sip-dev]
   fedora: [sip]
   gentoo: [=dev-python/sip-4*]
@@ -10075,6 +10079,7 @@ python3-singleton-pattern-decorator-pip:
     pip:
       packages: [singleton-pattern-decorator]
 python3-sip:
+  alpine: [py3-sip]
   debian: [python3-sip-dev]
   fedora: [python3-sip-devel]
   gentoo: [dev-python/sip]

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -57,9 +57,8 @@ package_dashboards:
 
 supported_versions:
   alpine:
-  - '3.8'
-  - '3.11'
-  - '3.14'
+  - '3.17'
+  - '3.20'
   debian:
   - bookworm
   fedora:


### PR DESCRIPTION
Currently Alpine 3.17 and 3.20 are supported by [alpine-ros](https://github.com/alpine-ros/alpine-ros).