### PR TITLE
Fix geographiclib for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1437,7 +1437,7 @@ gdal-bin:
   ubuntu: [gdal-bin]
 geographiclib:
   alpine:
-    '*': [geographiclib]
+    '*': [geographiclib-dev]
     '3.17': null
   debian:
     '*': [libgeographiclib-dev]


### PR DESCRIPTION
`-dev` package should be specified for geographiclib for consistency with other OSs.