### PR TITLE
Test only Alpine deps on CI

### DIFF
--- a/test/rosdep_repo_check/config.alpine-ros.yaml
+++ b/test/rosdep_repo_check/config.alpine-ros.yaml
@@ -1,0 +1,19 @@
+---
+package_sources:
+  alpine:
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/v$releasever/main
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/v$releasever/community
+  - !apk_base_url http://alpine-ros.seqsense.org/v$releasever/backports
+
+package_dashboards:
+- pattern: !regular_expression .*//dl-cdn.alpinelinux.org/alpine/[^/]+/([^/]+)/.*
+  url: https://pkgs.alpinelinux.org/package/{os_code_name}/\1/{os_arch}/{binary_name}
+
+supported_versions:
+  alpine:
+  - '3.17'
+  - '3.20'
+
+supported_arches:
+  alpine:
+  - x86_64

--- a/test/rosdep_repo_check/config.alpine-ros.yaml
+++ b/test/rosdep_repo_check/config.alpine-ros.yaml
@@ -18,4 +18,4 @@ supported_arches:
   alpine:
   - x86_64
 
-name_replacements:
+name_replacements: {}

--- a/test/rosdep_repo_check/config.alpine-ros.yaml
+++ b/test/rosdep_repo_check/config.alpine-ros.yaml
@@ -17,3 +17,5 @@ supported_versions:
 supported_arches:
   alpine:
   - x86_64
+
+name_replacements:

--- a/test/rosdep_repo_check/config.py
+++ b/test/rosdep_repo_check/config.py
@@ -39,7 +39,7 @@ from .rpm import rpm_mirrorlist_url
 
 DEFAULT_CONFIG_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)),
-    'config.yaml')
+    'config.alpine-ros.yaml')
 
 
 def load_apk_base_url(loader, node):

--- a/test/rosdep_repo_check/config.yaml
+++ b/test/rosdep_repo_check/config.yaml
@@ -1,9 +1,12 @@
 ---
 package_sources:
   alpine:
-  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/v$releasever/main
-  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/v$releasever/community
-  - !apk_base_url http://alpine-ros.seqsense.org/v$releasever/backports
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/main
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/community
+  - !apk_base_url https://dl-cdn.alpinelinux.org/alpine/$releasever/testing
+  arch:
+  - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ core
+  - !pacman_base_url https://archive.archlinux.org/repos/last/$repo/os/$arch/ extra
   debian:
   - !deb_base_url http://deb.debian.org/debian main
   - !deb_base_url http://deb.debian.org/debian contrib
@@ -57,8 +60,9 @@ package_dashboards:
 
 supported_versions:
   alpine:
-  - '3.17'
-  - '3.20'
+  - edge
+  arch:
+  - ''
   debian:
   - bookworm
   fedora:
@@ -78,6 +82,8 @@ supported_versions:
 
 supported_arches:
   alpine:
+  - x86_64
+  arch:
   - x86_64
   debian:
   - amd64


### PR DESCRIPTION
Suppress CI failure due to unrelated OS


Recently, CI often fails during loading repository of the other OS.
```
Reading RPM primary metadata from http://azure.repo.almalinux.org/9.6/AppStream/x86_64/os/repodata/d0b935883cbd42a3a8bddf0ba718ed26b0d25fe7f35c4f6da1dcbb9b7bd0679f-primary.xml.gz
F

...

 E               xml.etree.ElementTree.ParseError: not well-formed (invalid token): line 1, column 0

/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/xml/etree/ElementTree.py:1274: ParseError
```