### PR TITLE
Add libdw-dev entry for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -3743,6 +3743,7 @@ libdrm-dev:
   nixos: [libdrm]
   ubuntu: [libdrm-dev]
 libdw-dev:
+  alpine: [elfutils-dev]
   arch: [libelf]
   debian: [libdw-dev]
   fedora: [elfutils-devel]


### PR DESCRIPTION
To fix https://github.com/seqsense/aports-ros-updater/actions/runs/20083353913/job/57615419381#step:4:435

Packages
- 3.20: https://pkgs.alpinelinux.org/package/v3.20/main/x86_64/elfutils-dev