### PR TITLE
Add libnanoflann-dev entry for alpine

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5115,7 +5115,9 @@ libmysqlcppconn-dev:
   opensuse: [libmysqlcppconn-devel]
   ubuntu: [libmysqlcppconn-dev]
 libnanoflann-dev:
-  alpine: [nanoflann-dev]
+  alpine:
+    '*': [nanoflann-dev]
+    3.17: null
   debian:
     '*': [libnanoflann-dev]
     buster: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5117,7 +5117,7 @@ libmysqlcppconn-dev:
 libnanoflann-dev:
   alpine:
     '*': [nanoflann-dev]
-    3.17: null
+    '3.17': null
   debian:
     '*': [libnanoflann-dev]
     buster: null

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -5115,6 +5115,7 @@ libmysqlcppconn-dev:
   opensuse: [libmysqlcppconn-devel]
   ubuntu: [libmysqlcppconn-dev]
 libnanoflann-dev:
+  alpine: [nanoflann-dev]
   debian:
     '*': [libnanoflann-dev]
     buster: null


### PR DESCRIPTION
[nav2_route](https://github.com/ros-navigation/navigation2/blob/80b72d27811965a8a22b6d0e6f0cf95a7d74818a/nav2_route/package.xml#L27) needs this package

To fix https://github.com/seqsense/aports-ros-updater/actions/runs/20083353913/job/57621210210