### PR TITLE
Update rosdep keys for Alpine 3.23

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -21,8 +21,12 @@ ack-grep:
   ubuntu: [ack-grep]
 acl:
   alpine:
-    '*': [acl, acl-dev, acl-static, libacl]
+    '*': [acl, acl-dev, acl-static, acl-libs]
     '3.8': [acl, acl-dev, libacl]
+    '3.11': [acl, acl-dev, acl-static, libacl]
+    '3.14': [acl, acl-dev, acl-static, libacl]
+    '3.17': [acl, acl-dev, acl-static, libacl]
+    '3.20': [acl, acl-dev, acl-static, libacl]
   arch: [acl]
   debian: [acl, libacl1-dev]
   fedora: [acl, libacl-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -22,11 +22,11 @@ ack-grep:
 acl:
   alpine:
     '*': [acl, acl-dev, acl-static, acl-libs]
-    '3.8': [acl, acl-dev, libacl]
     '3.11': [acl, acl-dev, acl-static, libacl]
     '3.14': [acl, acl-dev, acl-static, libacl]
     '3.17': [acl, acl-dev, acl-static, libacl]
     '3.20': [acl, acl-dev, acl-static, libacl]
+    '3.8': [acl, acl-dev, libacl]
   arch: [acl]
   debian: [acl, libacl1-dev]
   fedora: [acl, libacl-devel]
@@ -1134,11 +1134,11 @@ fcgi:
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
 festival:
   alpine:
-    '3.8': [festival, festvox-kallpc16k]
     '3.11': [festival, festvox-kallpc16k]
     '3.14': [festival, festvox-kallpc16k]
     '3.17': [festival, festvox-kallpc16k]
     '3.20': [festival, festvox-kallpc16k]
+    '3.8': [festival, festvox-kallpc16k]
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]
   fedora: [festival, festvox-kal-diphone]
@@ -8239,11 +8239,11 @@ netcdf:
 netpbm:
   alpine:
     '*': [netpbm-dev]
-    '3.8': [libnetpbm-dev]
     '3.11': [libnetpbm-dev]
     '3.14': [libnetpbm-dev]
     '3.17': [libnetpbm-dev]
     '3.20': [libnetpbm-dev]
+    '3.8': [libnetpbm-dev]
   arch: [netpbm]
   debian: [libnetpbm10-dev]
   fedora: [netpbm-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -8223,7 +8223,13 @@ netcdf:
   nixos: [netcdf]
   ubuntu: [libnetcdf-dev]
 netpbm:
-  alpine: [libnetpbm-dev]
+  alpine:
+    '*': [netpbm-dev]
+    '3.8': [libnetpbm-dev]
+    '3.11': [libnetpbm-dev]
+    '3.14': [libnetpbm-dev]
+    '3.17': [libnetpbm-dev]
+    '3.20': [libnetpbm-dev]
   arch: [netpbm]
   debian: [libnetpbm10-dev]
   fedora: [netpbm-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9639,7 +9639,13 @@ sdformat13:
   gentoo: ['dev-libs/sdformat:13']
   nixos: [sdformat_13]
 sdl:
-  alpine: [sdl-dev]
+  alpine:
+    '*': [sdl12-compat-dev]
+    '3.20': [sdl-dev]
+    '3.17': [sdl-dev]
+    '3.14': [sdl-dev]
+    '3.11': [sdl-dev]
+    '3.8': [sdl-dev]
   arch: [sdl12-compat]
   debian: [libsdl1.2-dev]
   fedora: [SDL-devel]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1133,7 +1133,12 @@ fcgi:
   openembedded: [fcgi@meta-webserver]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
 festival:
-  alpine: [festival, festvox-kallpc16k]
+  alpine:
+    '3.8': [festival, festvox-kallpc16k]
+    '3.11': [festival, festvox-kallpc16k]
+    '3.14': [festival, festvox-kallpc16k]
+    '3.17': [festival, festvox-kallpc16k]
+    '3.20': [festival, festvox-kallpc16k]
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]
   fedora: [festival, festvox-kal-diphone]
@@ -2181,7 +2186,12 @@ haproxy:
   nixos: [haproxy]
   ubuntu: [haproxy]
 hddtemp:
-  alpine: [hddtemp]
+  alpine:
+    '3.11': [hddtemp]
+    '3.14': [hddtemp]
+    '3.17': [hddtemp]
+    '3.20': [hddtemp]
+    '3.8': [hddtemp]
   arch: [hddtemp]
   debian: [hddtemp]
   fedora: [hddtemp]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9641,10 +9641,10 @@ sdformat13:
 sdl:
   alpine:
     '*': [sdl12-compat-dev]
-    '3.20': [sdl-dev]
-    '3.17': [sdl-dev]
-    '3.14': [sdl-dev]
     '3.11': [sdl-dev]
+    '3.14': [sdl-dev]
+    '3.17': [sdl-dev]
+    '3.20': [sdl-dev]
     '3.8': [sdl-dev]
   arch: [sdl12-compat]
   debian: [libsdl1.2-dev]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -2777,11 +2777,11 @@ python-opencv-contrib-pip:
 python-opengl:
   alpine:
     '*': [py3-opengl]
-    '3.8': [py-opengl]
     '3.11': [py-opengl]
     '3.14': [py-opengl]
     '3.17': [py-opengl]
     '3.20': [py-opengl]
+    '3.8': [py-opengl]
   arch: [python2-opengl]
   debian: [python-opengl]
   freebsd: [py27-PyOpenGL]

--- a/rosdep/python.yaml
+++ b/rosdep/python.yaml
@@ -528,7 +528,13 @@ pyros-setup-pip:
     pip:
       packages: [pyros-setup]
 pysdl2:
-  alpine: [py-pysdl2]
+  alpine:
+    '*': [py3-pysdl2]
+    '3.11': [py-pysdl2]
+    '3.14': [py-pysdl2]
+    '3.17': [py-pysdl2]
+    '3.20': [py-pysdl2]
+    '3.8': [py-pysdl2]
   debian:
     pip:
       packages: [pysdl2]
@@ -536,7 +542,13 @@ pysdl2:
     pip:
       packages: [pysdl2]
 pysdl2-dll:
-  alpine: [py-pysdl2-dll]
+  alpine:
+    '*': [py3-pysdl2-dll]
+    '3.11': [py-pysdl2-dll]
+    '3.14': [py-pysdl2-dll]
+    '3.17': [py-pysdl2-dll]
+    '3.20': [py-pysdl2-dll]
+    '3.8': [py-pysdl2-dll]
   debian:
     pip:
       packages: [pysdl2-dll]
@@ -2763,7 +2775,13 @@ python-opencv-contrib-pip:
     pip:
       packages: [opencv-contrib-python]
 python-opengl:
-  alpine: [py-opengl]
+  alpine:
+    '*': [py3-opengl]
+    '3.8': [py-opengl]
+    '3.11': [py-opengl]
+    '3.14': [py-opengl]
+    '3.17': [py-opengl]
+    '3.20': [py-opengl]
   arch: [python2-opengl]
   debian: [python-opengl]
   freebsd: [py27-PyOpenGL]

--- a/test/rosdep_repo_check/config.alpine-ros.yaml
+++ b/test/rosdep_repo_check/config.alpine-ros.yaml
@@ -11,8 +11,8 @@ package_dashboards:
 
 supported_versions:
   alpine:
-  - '3.17'
   - '3.20'
+  - '3.23'
 
 supported_arches:
   alpine:


### PR DESCRIPTION
- Update test target
- Use `sdl12-compat` instead of the backported sdl 1.2
- `libacl` is renamed to `acl-libs`
- `libnetpbm-dev` (built by aports-ros-experimental) is changed to `netpbm-dev` (Alpine official)
- Remove `hddtemp` and `festival`