### PR TITLE
Add festival back to all Alpine versions

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -1133,12 +1133,7 @@ fcgi:
   openembedded: [fcgi@meta-webserver]
   ubuntu: [libfcgi-dev, libapache2-mod-fastcgi, spawn-fcgi]
 festival:
-  alpine:
-    '3.11': [festival, festvox-kallpc16k]
-    '3.14': [festival, festvox-kallpc16k]
-    '3.17': [festival, festvox-kallpc16k]
-    '3.20': [festival, festvox-kallpc16k]
-    '3.8': [festival, festvox-kallpc16k]
+  alpine: [festival, festvox-kallpc16k]
   arch: [festival, festival-english]
   debian: [festival, festvox-kallpc16k]
   fedora: [festival, festvox-kal-diphone]


### PR DESCRIPTION
`festival` is required by `audio_common/sound_play` package.