### PR TITLE
Fix library dependency of sdl on 3.23

### DIFF
--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9932,7 +9932,7 @@ sdformat13:
   nixos: [sdformat_13]
 sdl:
   alpine:
-    '*': [sdl12-compat-dev, sdl2-dev]
+    '*': [sdl12-compat-dev, sdl2]
     '3.11': [sdl-dev]
     '3.14': [sdl-dev]
     '3.17': [sdl-dev]

--- a/rosdep/base.yaml
+++ b/rosdep/base.yaml
@@ -9932,7 +9932,7 @@ sdformat13:
   nixos: [sdformat_13]
 sdl:
   alpine:
-    '*': [sdl12-compat-dev]
+    '*': [sdl12-compat-dev, sdl2-dev]
     '3.11': [sdl-dev]
     '3.14': [sdl-dev]
     '3.17': [sdl-dev]


### PR DESCRIPTION
`sdl12-compat-dev` is used for `sdl` rosdep key since 3.23 but the actual library `sdl2` should be also installed to add a runtime dependency.